### PR TITLE
Update includes and remove unused variable

### DIFF
--- a/Source/WindowsDualsense_ds5w/Public/Core/DeviceContainerManager.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DeviceContainerManager.h
@@ -83,12 +83,6 @@ public:
 	 * @return The number of allocated device library instances.
 	 */
 	static int32 GetAllocatedDevices();
-	/**
-	 * A static instance of FGenericPlatformInputDeviceMapper used to handle mapping of input devices
-	 * across different platforms. This variable helps manage the relationship between controllers
-	 * and their respective input configurations, ensuring seamless integration and functionality.
-	 */
-	static FGenericPlatformInputDeviceMapper PlatformInputDeviceMapper;
 	
 private:
 	/**

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -6,15 +6,16 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
-#include "InputCoreTypes.h"
-#include "Core/Enums/EDeviceCommons.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
-#include "Core/Structs/FDeviceContext.h"
-#include "Core/Structs/FDualSenseFeatureReport.h"
+#include "InputCoreTypes.h"
 #include "Misc/CoreDelegates.h"
 #include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
 #include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
+#include "Core/Enums/EDeviceCommons.h"
+#include "Core/Structs/FDeviceContext.h"
+#include "Core/Structs/FDeviceSettings.h"
+#include "Core/Structs/FDualSenseFeatureReport.h"
 #include "DualSenseLibrary.generated.h"
 
 /**

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
@@ -9,6 +9,10 @@
 #include "Core/Enums/EDeviceCommons.h"
 #include "Core/Structs/FDeviceContext.h"
 #include "Core/Structs/FDeviceSettings.h"
+#include "InputCoreTypes.h"
+#include "Misc/CoreDelegates.h"
+#include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
+#include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
 #include "SonyGamepadInterface.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
@@ -6,6 +6,7 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"
+#include "Templates/SharedPointer.h"
 #include "SonyGamepadTriggerInterface.generated.h"
 
 // This class does not need to be modified.

--- a/WindowsDualsense_ds5w.uplugin
+++ b/WindowsDualsense_ds5w.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.2.6",
+	"VersionName": "1.2.7",
 	"FriendlyName": "WindowsDualsense_ds5w",
 	"Description": "Dualsense PS5 device for Windows platforms. Zero Configs. Supports settings of triggers, force feedback, vibrations, leds, battery level, microphone",
 	"Category": "Input Devices",


### PR DESCRIPTION
Reordered and added necessary include statements in several header files for improved clarity and dependency management. Removed the unused static PlatformInputDeviceMapper variable from DeviceContainerManager. Bumped plugin version to 1.2.7.