### PR TITLE
Refactor DualSenseProxy for unified device handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,21 @@
 ![GitHub License](https://img.shields.io/github/license/rafaelvaloto/WindowsDualsenseUnreal)
 ![GitHub contributors](https://img.shields.io/github/contributors/rafaelvaloto/WindowsDualsenseUnreal)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/rafaelvaloto/WindowsDualsenseUnreal)
-![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/rafaelvaloto/WindowsDualsenseUnreal)
-![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/rafaelvaloto/WindowsDualsenseUnreal/total)
+
+## Important Note (since v1.2.7)
+
+Starting from version **1.2.7**, it is recommended to use the following functions from the `USonyGamepadProxy` class for device status and common effect operations.  
+These functions provide unified handling for both DualSense and DualShock (in development):
+
+- `DeviceIsConnected`
+- `DeviceReconnect`
+- `DeviceDisconnect`
+- `LevelBatteryDevice`
+- `LedColorEffects`
+- `LedPlayerEffects`
+- `LedMicEffects`
+
+Please prefer these functions for checking device status or applying common LED and vibration effects across supported controllers.
 
 
 ### **Plugin with full support for the DualSense PS5 controller in Unreal Engine versions  5.2 ~ 5.6, for Windows platforms. No configuration needed**
@@ -64,95 +77,159 @@ The plugin now features audio-based vibration support, enabling controller vibra
 
 ### Trigger effects
 ```
-    // Forces max value 8
-    // Positions max value 8
-    
-    int32 ControllerId = 0; 
+MyClass::MyClass()
+{
+	/**
+	 * Triggers a haptic feedback effect for an automatic gun using the DualSense controller.
+	 *
+	 * @param ControllerId The ID of the controller to apply the effect on.
+	 * @param BeginStrength The starting vibration strength of the trigger effect. If invalid, a default value of 8 is used.
+	 * @param MiddleStrength The middle vibration strength of the trigger effect. If invalid, a default value of 8 is used.
+	 * @param EndStrength The ending vibration strength of the trigger effect. If invalid, a default value of 8 is used.
+	 * @param Hand The controller hand (left or right) to which the effect is applied.
+	 * @param KeepEffect Whether to keep the effect active continuously.
+	 */
+	UDualSenseProxy::AutomaticGun(0, 0, 0, 8, EControllerHand::Left, true);
 
-    UDualSenseProxy::EffectWeapon(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 Force, EControllerHand Hand);
-      
-    UDualSenseProxy::EffectGalloping(ControllerId, 5, 8, 5, 7, 0.01f, EControllerHand::Left);
-    UDualSenseProxy::EffectGalloping(ControllerId, 0, 5, 0, 4, 0.005f, EControllerHand::Right);
-      
-    UDualSenseProxy::EffectMachine(ControllerId, 1, 5, 1, 5, 0.5f, 3.f, EControllerHand::Left);
-    UDualSenseProxy::EffectMachine(ControllerId, 5, 8, 5, 8, 0.4f, 1.0f, EControllerHand::Right);
-      
-    UDualSenseProxy::EffectBow(ControllerId, 0, 5, 5, 8, EControllerHand::Left);
-    UDualSenseProxy::EffectBow(ControllerId, 5, 8, 8, 8, EControllerHand::Right);
-      
-    UDualSenseProxy::EffectContinuousResitance(int32 ControllerId, int32 StartPosition, int32 EndPosition, EControllerHand Hand);
-    UDualSenseProxy::EffectContinuousResitance(ControllerId, 1, 4, EControllerHand::Right);
+	/**
+	 * Configures a weapon effect on the DualSense controller using specified parameters.
+	 *
+	 * @param ControllerId The identifier for the target DualSense controller.
+	 * @param StartPosition The starting position of the effect in the trigger. The value should be validated and within the range of allowed positions.
+	 * @param EndPosition The ending position of the effect in the trigger. The value should be validated and within the range of allowed positions.
+	 * @param Strength The strength of the weapon effect. The value should be validated and within the range of allowed strengths.
+	 * @param Hand Specifies which controller hand (left or right) should be affected by the weapon effect.
+	 */
+	UDualSenseProxy::Weapon(0, 0, 0, 8, EControllerHand::AnyHand);
 
-    // Start position max value 8 | Forces max value 8
-    UDualSenseProxy::EffectSectionResitance(ControllerId, 1, 8, EControllerHand::Left); 
-    UDualSenseProxy::EffectContinuousResitance(ControllerId, 5, 8, EControllerHand::Right);
+	/**
+	 * @brief Triggers a galloping vibration effect on a DualSense controller.
+	 *
+	 * This function sets up and activates a galloping vibration pattern by defining
+	 * the movement positions, associated vibration intensity, frequency, and the hand
+	 * where the effect plays.
+	 *
+	 * @param ControllerId The ID of the controller to apply the effect.
+	 * @param StartPosition The initial position of the galloping effect.
+	 * @param EndPosition The final position of the galloping effect.
+	 * @param FirstFoot The intensity for the first "foot" step in the galloping effect. 
+	 * @param SecondFoot The intensity for the second "foot" step in the galloping effect.
+	 * @param Frequency The frequency at which the galloping effect repeats.
+	 * @param Hand Specifies whether the effect is applied to the left or right hand.
+	 */
+	UDualSenseProxy::Galloping(0, 2, 5, 2, 5, 0.005, EControllerHand::Left);
+
+	/**
+	 * Applies a resistance effect to the trigger of a PlayStation DualSense controller.
+	 *
+	 * This method configures the specified trigger to provide resistance feedback based on
+	 * the given start position, end position, and strength parameters. The effect is applied
+	 * to the controller defined by the ControllerId and the trigger specified using the Hand parameter.
+	 *
+	 * @param ControllerId The identifier of the controller to apply the resistance effect.
+	 * @param StartPosition The starting position of the resistance zone within the trigger's range. Value must be between 0 and 8.
+	 * @param EndPosition The ending position of the resistance zone within the trigger's range. Value must be between 0 and 8.
+	 * @param Strength The strength of the resistance effect. Value must be between 0 and 8, with higher values indicating stronger resistance.
+	 * @param Hand The trigger to apply the effect to, specified as EControllerHand (e.g., Left or Right).
+	 */
+	UDualSenseProxy::Resistance(0, 1, 8, 8, EControllerHand::Right);
+	
+}
 ```
 ### Example reset effects
 ```
-    int32 ControllerId = 0;
-   
-    // Stop triggers effects
-    UDualSenseProxy::StopAllTriggersEffects(ControllerId);
-    UDualSenseProxy::StopTriggerEffect(ControllerId, EControllerHand::Left);
-    UDualSenseProxy::StopTriggerEffect(ControllerId, EControllerHand::Right);
+MyClass::MyClass()
+{
+	/**
+	 * Stops all trigger effects currently active for the specified DualSense controller.
+	 *
+	 * @param ControllerId The ID of the DualSense controller for which to stop all trigger effects.
+	 */
+	UDualSenseProxy::StopAllTriggersEffects(0);
 
-    // Normalize triggers
-    UDualSenseProxy::EffectNoResitance(ControllerId, EControllerHand::Left);
-    UDualSenseProxy::EffectNoResitance(ControllerId, EControllerHand::Right);
-    
-    // Normalize triggers
-    UDualSenseProxy::EffectNoResitance(ControllerId, EControllerHand::Left);
-    UDualSenseProxy::EffectNoResitance(ControllerId, EControllerHand::Right);
+	/**
+	 * Stops the trigger effect on a specific controller for the specified hand.
+	 *
+	 * @param ControllerId The unique identifier of the controller for which the trigger effect should be stopped.
+	 * @param HandStop Specifies which hand's trigger effect (left or right) should be stopped.
+	 */
+	UDualSenseProxy::StopTriggerEffect(0, EControllerHand::Left);
+	UDualSenseProxy::StopTriggerEffect(0, EControllerHand::Right);
+	UDualSenseProxy::StopTriggerEffect(0, EControllerHand::AnyHand);
+}
 ```
-### Example haptics effects
-```
-   int32 ControllerId = 0; 
-   
-    // Start position max value 8 | Forces max value 8
-    UDualSenseProxy::SetTriggerHapticFeedbackEffect(ControllerId, 8, 0, 0, 6, EControllerHand::Left, true);
-    UDualSenseProxy::SetTriggerHapticFeedbackEffect(ControllerId, 8, 0, 0, 7, EControllerHand::Right, true);
+>NOTE: Support for **DualShock 4** controllers is still under development.  
+Some features may be incomplete or unavailable in the current version.
 
-    // SetHapticsByValue is a method of PlayerController.
-    SetHapticsByValue(0.1f, 1.0f, EControllerHand::Left);
-    SetHapticsByValue(1.0f, 1.0f, EControllerHand::Right);
+### Configs Commons (DualSense) and (DualShock 4)
 ```
+    /**
+	 * Checks if the DualSense or DualShock device with the specified Controller ID is connected.
+	 *
+	 * @param ControllerId The ID of the controller to check for connectivity.
+	 * @return True if the DualSense or DualShock  device is connected, false otherwise.
+	 */
+	USonyGamepadProxy::DeviceIsConnected(int32 ControllerId);
 
-### Players and led effects
-```
-   #include "DualSenseProxy.h"
-   
-   void APlayerController::BeginPlay()
-   {
-       Super::BeginPlay();
-       
-       int32 ControllerId = 0; 
-       
-       // Reset buffer all values 
-       UDualSenseProxy::ResetEffects(ControllerId);
-       
-       // Gyroscope and Accelerometer are set to false by default.
-       UDualSenseProxy::EnableAccelerometerValues(ControllerId, false);
-       UDualSenseProxy::EnableGyroscopeValues(ControllerId, false);
-   
-       // Touch pad values default false
-       UDualSenseProxy::EnableTouch1(ControllerId, false);
-       UDualSenseProxy::EnableTouch2(ControllerId, false);
-   
-       // Level battery Full load max 100.0f
-       float levelBattery = UDualSenseProxy::LevelBatteryDevice(ControllerId);
-   
-       // Leds configs
-       UDualSenseProxy::LedMicEffects(ControllerId, ELedMicEnum::MicOn);
-       UDualSenseProxy::LedPlayerEffects(ControllerId, ELedPlayerEnum::One, ELedBrightnessEnum::Medium);
-       UDualSenseProxy::LedColorEffects(ControllerId, FColor(255, 255, 255));
-   }
+	/**
+	 * Attempts to reconnect a DualSense or DualShock controller based on the given controller ID.
+	 * If the controller is successfully reconnected, the operation returns true;
+	 * otherwise, it returns false.
+	 *
+	 * @param ControllerId The ID of the controller to reconnect.
+	 * @return Returns true if the controller was successfully reconnected, false otherwise.
+	 */
+	USonyGamepadProxy::DeviceReconnect(int32 ControllerId);
+
+	/**
+	 * Disconnects the DualSense or DualShock device associated with the given Controller ID.
+	 * This method removes the library instance associated with the specified controller.
+	 *
+	 * @param ControllerId The ID of the DualSense or DualShock or DualShock controller to be disconnected.
+	 * @return true if the disconnection was initiated successfully.
+	 */
+	USonyGamepadProxy::DeviceDisconnect(int32 ControllerId);
+
+	/**
+	 * Retrieves the battery level of the DualSense or DualShock controller for the specified controller ID.
+	 *
+	 * This method uses the DualSense or DualShock library instance associated with the provided controller ID
+	 * to fetch the battery level. If the library instance is not found, the method returns 0.0f.
+	 *
+	 * @param ControllerId The ID of the DualSense or DualShock controller to query.
+	 * @return The battery level of the controller as a float. Returns 0.0f if the library instance cannot be retrieved.
+	 */
+	USonyGamepadProxy::LevelBatteryDevice(int32 ControllerId);
+
+	/**
+	 * Updates the LED color effects on a DualSense controller using the specified color.
+	 *
+	 * @param ControllerId The identifier of the controller whose LED color will be updated.
+	 * @param Color The color to set on the controller's LED.
+	 */
+	USonyGamepadProxy::LedColorEffects(int32 ControllerId, FColor Color);
+
+	/**
+	 * Controls the LED player light effects on the DualSense controller.
+	 *
+	 * @param ControllerId The identifier for the target controller.
+	 * @param Value The LED pattern enum specifying the LED configuration for the player indicator (e.g., Off, Player One, Player Two, etc.).
+	 * @param Brightness The brightness level of the LED lights specified by an enum (e.g., Low, Medium, High).
+	 */
+	USonyGamepadProxy::LedPlayerEffects(int32 ControllerId, ELedPlayerEnum Value, ELedBrightnessEnum Brightness);
+
+	/**
+	 * Controls the LED and microphone visual effects on a DualSense controller.
+	 *
+	 * @param ControllerId The ID of the DualSense controller to be affected.
+	 * @param Value The desired LED and microphone effect to apply, represented as an ELedMicEnum value.
+	 */
+	USonyGamepadProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value);
 
 ```
 ### Vibrations
-
-##### The plugin is compatible with Unreal's native Blueprints Force Feedback
 ``` 
-    // Vibrations example 
+    // Vibrations example
     PlayDynamicForceFeedback(0.5f, 3.f, true, true, true, true);
 ```
 ## Multiple players with multiple controllers

--- a/Source/WindowsDualsense_ds5w/Private/Core/DeviceHIDManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DeviceHIDManager.cpp
@@ -70,8 +70,15 @@ bool UDeviceHIDManager::FindDevices(TArray<FDeviceContext>& Devices)
 
 				if (HidD_GetAttributes(TempDeviceHandle, &Attributes))
 				{
-					if (Attributes.VendorID == 0x054C && (Attributes.ProductID == 0x0CE6 || Attributes.ProductID ==
-						0x0DF2))
+					if (
+						Attributes.VendorID == 0x054C &&
+						(
+							Attributes.ProductID == 0x0CE6 ||
+							Attributes.ProductID == 0x0DF2 ||
+							Attributes.ProductID == 0x05C4 ||
+							Attributes.ProductID == 0x09CC
+						)
+					)
 					{
 						FDeviceContext Context = {};
 						size_t PathSize = 260;
@@ -89,9 +96,21 @@ bool UDeviceHIDManager::FindDevices(TArray<FDeviceContext>& Devices)
 						
 						DevicePaths.Add(DeviceIndex, *DetailDataBuffer->DevicePath);
 						wcscpy_s(Context.Path, DetailDataBuffer->DevicePath);
-						
+
+						switch (Attributes.ProductID)
+						{
+							case 0x05C4:
+							case 0x09CC:
+								Context.DeviceType = DualShock;
+								break;
+							case 0x0DF2:
+								Context.DeviceType = Edge;
+								break;
+							default: Context.DeviceType = Default;
+						}
 						Context.IsConnected = true;
 						Context.ConnectionType = Usb;
+						
 						FString DevicePath(DetailDataBuffer->DevicePath);
 						if (DevicePath.Contains(TEXT("{00001124-0000-1000-8000-00805f9b34fb}")) ||
 							DevicePath.Contains(TEXT("bth")) ||

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
@@ -15,6 +15,8 @@ bool UDualSenseLibrary::InitializeLibrary(const FDeviceContext& Context)
 {
 	HIDDeviceContexts = Context;
 	StopAll();
+	
+	UE_LOG(LogTemp, Log, TEXT("Initializing device model (%s)"), Context.DeviceType == Edge ? TEXT("DualSense Edge") : TEXT("DualSense Default"));
 	return true;
 }
 
@@ -42,9 +44,7 @@ void UDualSenseLibrary::SendOut()
 	{
 		return;
 	}
-
 	
-	UE_LOG(LogTemp, Warning, TEXT("Output Sending HID report, ControllerId: %d, Color: %d, %d, %d"), ControllerID, HIDDeviceContexts.Output.Lightbar.R, HIDDeviceContexts.Output.Lightbar.G, HIDDeviceContexts.Output.Lightbar.B);
 	UDeviceHIDManager::OutputBuffering(&HIDDeviceContexts);
 }
 void UDualSenseLibrary::Settings(const FSettings<FFeatureReport>& Settings)
@@ -108,6 +108,11 @@ bool UDualSenseLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 		)
 	{
 		const unsigned char* HIDInput = &HIDDeviceContexts.Buffer[Padding];
+
+		/**
+		 * TODO: Implement a conditional that checks if `Context.DeviceType` is set to `Edge`.
+		 * If true, execute the logic specific to the DualSense Edge controller.
+		 */
 
 		// Analogs
 		const float LeftAnalogX = static_cast<char>(static_cast<short>(HIDInput[0x00] - 128));

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -5,6 +5,7 @@
 #include <Windows.h>
 #include "Core/DeviceHIDManager.h"
 #include "InputCoreTypes.h"
+#include "VREditorMode.h"
 #include "Core/Structs/FOutputContext.h"
 #include "Helpers/ValidateHelpers.h"
 
@@ -19,6 +20,8 @@ void UDualShockLibrary::Settings(const FDualShockFeatureReport& Settings)
 bool UDualShockLibrary::InitializeLibrary(const FDeviceContext& Context)
 {
 	HIDDeviceContexts = Context;
+
+	UE_LOG(LogTemp, Log, TEXT("Initializing device model (DualShock 4)"));
 	return true;
 }
 
@@ -82,33 +85,45 @@ bool UDualShockLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 
 void UDualShockLibrary::SetLightbar(FColor Color)
 {
+	// TODO: Implement the logic for the DualShock Lightbar buffer
+	SendOut();
 }
 
 void UDualShockLibrary::SetPlayerLed(ELedPlayerEnum Led, ELedBrightnessEnum Brightness)
 {
+	// TODO: Implement the logic for the DualShock PlayerLed buffer
+	SendOut();
 }
 
 void UDualShockLibrary::SetMicrophoneLed(ELedMicEnum Led)
 {
+	// TODO: Implement the logic for the DualShock MicrophoneLed buffer
+	SendOut();
 }
 
 void UDualShockLibrary::SetTouch(const bool bIsTouch)
 {
+	EnableTouch = bIsTouch;
 }
 
 void UDualShockLibrary::SetAcceleration(bool bIsAccelerometer)
 {
+	EnableAccelerometerAndGyroscope = bIsAccelerometer;
 }
 
 void UDualShockLibrary::SetGyroscope(bool bIsGyroscope)
 {
+	EnableAccelerometerAndGyroscope = bIsGyroscope;
 }
 
 void UDualShockLibrary::StopAll()
 {
+	// TODO: Implement the logic for the DualShock Reset buffer
+	SendOut();
 }
 
 void UDualShockLibrary::SetVibration(const FForceFeedbackValues& Values)
 {
 	// TODO: Implement the logic for output the DualShock Vibrations
+	SendOut();
 }

--- a/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
@@ -27,12 +27,23 @@ void UDualSenseProxy::DeviceSettings(int32 ControllerId, FDualSenseFeatureReport
 	DualSenseInstance->Settings(Settings);
 }
 
+/**
+ * TODO:
+ * Deprecate this function DeviceDisconnect.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
 bool UDualSenseProxy::DeviceDisconnect(int32 ControllerId)
 {
 	UDeviceContainerManager::Get()->RemoveLibraryInstance(ControllerId);
 	return true;
 }
-
+/**
+ * TODO:
+ * Deprecate this function DeviceReconnect.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
 bool UDualSenseProxy::DeviceReconnect(int32 ControllerId)
 {
 	if (const ISonyGamepadInterface* Gamepad = UDeviceContainerManager::Get()->GetLibraryOrReconnect(ControllerId); !Gamepad)
@@ -42,7 +53,12 @@ bool UDualSenseProxy::DeviceReconnect(int32 ControllerId)
 
 	return true;
 }
-
+/**
+ * TODO:
+ * Deprecate this function DeviceIsConnected.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
 bool UDualSenseProxy::DeviceIsConnected(int32 ControllerId)
 {
 	if (const ISonyGamepadInterface* Gamepad = UDeviceContainerManager::Get()->GetLibraryOrReconnect(ControllerId); !Gamepad)
@@ -52,7 +68,12 @@ bool UDualSenseProxy::DeviceIsConnected(int32 ControllerId)
 
 	return true;
 }
-
+/**
+ * TODO:
+ * Deprecate this function LevelBatteryDevice.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
 float UDualSenseProxy::LevelBatteryDevice(int32 ControllerId)
 {
 	ISonyGamepadInterface* Gamepad = UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId);
@@ -62,6 +83,102 @@ float UDualSenseProxy::LevelBatteryDevice(int32 ControllerId)
 	}
 
 	return Gamepad->GetBattery();
+}
+/**
+ * TODO:
+ * Deprecate this function LedPlayerEffects.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::LedPlayerEffects(int32 ControllerId, ELedPlayerEnum Value, ELedBrightnessEnum Brightness)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetPlayerLed(Value, Brightness);
+}
+/**
+ * TODO:
+ * Deprecate this function LedMicEffects.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetMicrophoneLed(Value);
+}
+/**
+ * TODO:
+ * Deprecate this function LedColorEffects.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::LedColorEffects(int32 ControllerId, FColor Color)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetLightbar(Color);
+}
+/**
+ * TODO:
+ * Deprecate this function EnableTouch.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetTouch(bEnableTouch);
+}
+/**
+ * TODO:
+ * Deprecate this function EnableAccelerometerValues.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetAcceleration(bEnableAccelerometer);
+}
+/**
+ * TODO:
+ * Deprecate this function EnableGyroscopeValues.
+ * It is already being used by the USonyGamepadProxy class, which handles the common functions for DualSense and DualShock.
+ * 
+ */
+void UDualSenseProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGyroscope)
+{
+	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
+	if (!IsValid(Gamepad->_getUObject()))
+	{
+		return;
+	}
+
+	Gamepad->SetGyroscope(bEnableGyroscope);
 }
 
 void UDualSenseProxy::SetVibrationFromAudio(
@@ -148,13 +265,13 @@ void UDualSenseProxy::ContinuousResistance(int32 ControllerId, int32 StartPositi
 }
 
 void UDualSenseProxy::Galloping(
-	int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 BeginStrength,
-                                int32 EndStrength, float Frequency, EControllerHand Hand)
+	int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 FirstFoot,
+                                int32 SecondFoot, float Frequency, EControllerHand Hand)
 {
 	if (!UValidateHelpers::ValidateMaxPosition(StartPosition)) StartPosition = 0;
 	if (!UValidateHelpers::ValidateMaxPosition(EndPosition)) EndPosition = 8;
-	if (!UValidateHelpers::ValidateMaxPosition(BeginStrength)) BeginStrength = 0;
-	if (!UValidateHelpers::ValidateMaxPosition(EndStrength)) EndStrength = 8;
+	if (!UValidateHelpers::ValidateMaxPosition(FirstFoot)) FirstFoot = 2;
+	if (!UValidateHelpers::ValidateMaxPosition(SecondFoot)) SecondFoot = 7;
 
 	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
 	if (!IsValid(Gamepad->_getUObject()))
@@ -162,7 +279,7 @@ void UDualSenseProxy::Galloping(
 		return;
 	}
 	
-	Gamepad->SetGalloping(StartPosition, EndPosition, BeginStrength, EndStrength, Frequency, Hand);
+	Gamepad->SetGalloping(StartPosition, EndPosition, FirstFoot, SecondFoot, Frequency, Hand);
 }
 
 void UDualSenseProxy::Machine(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 FirstFoot,
@@ -213,72 +330,6 @@ void UDualSenseProxy::Bow(int32 ControllerId, int32 StartPosition, int32 EndPosi
 	}
 
 	Gamepad->SetBow(StartPosition, EndPosition, BeginStrength, EndStrength, Hand);
-}
-
-void UDualSenseProxy::LedPlayerEffects(int32 ControllerId, ELedPlayerEnum Value, ELedBrightnessEnum Brightness)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetPlayerLed(Value, Brightness);
-}
-
-void UDualSenseProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetMicrophoneLed(Value);
-}
-
-void UDualSenseProxy::LedColorEffects(int32 ControllerId, FColor Color)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetLightbar(Color);
-}
-
-void UDualSenseProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetTouch(bEnableTouch);
-}
-
-void UDualSenseProxy::EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetAcceleration(bEnableAccelerometer);
-}
-
-void UDualSenseProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGyroscope)
-{
-	ISonyGamepadInterface* Gamepad = Cast<ISonyGamepadInterface>(UDeviceContainerManager::Get()->GetLibraryInstance(ControllerId));
-	if (!IsValid(Gamepad->_getUObject()))
-	{
-		return;
-	}
-
-	Gamepad->SetGyroscope(bEnableGyroscope);
 }
 
 void UDualSenseProxy::NoResistance(int32 ControllerId, EControllerHand Hand)

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -263,6 +263,27 @@ private:
 	 */
 	float LevelBattery;
 	/**
+	 * @brief A variable that indicates whether touch functionality is enabled or disabled.
+	 *
+	 * This variable is used to toggle the touch input capability of the system or application.
+	 * When set to true, touch input is enabled, allowing the system to respond to touch events.
+	 * When set to false, touch input is disabled, and touch interactions are ignored.
+	 */
+	bool EnableTouch;
+	/**
+	 * @variable EnableAccelerometerAndGyroscope
+	 * @brief Flags the activation of accelerometer and gyroscope sensors in the system.
+	 *
+	 * This variable determines whether the accelerometer and gyroscope functionalities
+	 * are enabled for the system. When set to true, data from these sensors will be collected
+	 * and utilized, typically for motion detection or orientation tracking.
+	 *
+	 * @details This flag is often used in systems that require motion input for functionality,
+	 * such as gaming controllers, virtual reality devices, or motion-sensing applications.
+	 * Disabling this may reduce resource usage but will disable motion-based features.
+	 */
+	bool EnableAccelerometerAndGyroscope;
+	/**
 	 * @brief Represents the context of a Human Interface Device (HID) used by DualSense controllers.
 	 *
 	 * This variable holds the FDeviceContext structure, which encapsulates the necessary state and

--- a/Source/WindowsDualsense_ds5w/Public/DualSenseProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/DualSenseProxy.h
@@ -217,16 +217,21 @@ public:
 		EControllerHand Hand
 	);
 
+
 	/**
-	 * Triggers a galloping haptic effect on the DualSense controller.
+	 * @brief Triggers a galloping vibration effect on a DualSense controller.
 	 *
-	 * @param ControllerId The ID of the controller to apply the effect to.
-	 * @param StartPosition The starting actuator position for the galloping effect. Valid range is 0-8.
-	 * @param EndPosition The ending actuator position for the galloping effect. Valid range is 0-8.
-	 * @param BeginStrength The initial strength of the effect. Valid range is 0-8.
-	 * @param EndStrength The final strength of the effect. Valid range is 0-8.
-	 * @param Frequency The frequency of the galloping effect.
-	 * @param Hand Specifies which hand is being used (left or right).
+	 * This function sets up and activates a galloping vibration pattern by defining
+	 * the movement positions, associated vibration intensity, frequency, and the hand
+	 * where the effect plays.
+	 *
+	 * @param ControllerId The ID of the controller to apply the effect.
+	 * @param StartPosition The initial position of the galloping effect.
+	 * @param EndPosition The final position of the galloping effect.
+	 * @param FirstFoot The intensity for the first "foot" step in the galloping effect.
+	 * @param SecondFoot The intensity for the second "foot" step in the galloping effect.
+	 * @param Frequency The frequency at which the galloping effect repeats.
+	 * @param Hand Specifies whether the effect is applied to the left or right hand.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void Galloping(
@@ -236,9 +241,9 @@ public:
 		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
 		int32 EndPosition,
 		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 BeginStrength,
+		int32 FirstFoot,
 		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndStrength,
+		int32 SecondFoot,
 		UPARAM(meta = (ClampMin = "0.01", ClampMax = "1.0", UIMin = "0.01", UIMax = "1.0"))
 		float Frequency,
 		EControllerHand Hand


### PR DESCRIPTION
Deprecated several UDualSenseProxy functions in favor of USonyGamepadProxy for unified DualSense and DualShock support. Updated README with new usage recommendations and improved documentation. Added device type detection and logging for DualShock and DualSense Edge. Refactored galloping effect parameters and enhanced code comments for clarity. Added internal flags for touch and motion sensor support in DualShockLibrary.