### PR TITLE
Add DualShock 4 Bluetooth support and buffer handling

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -19,6 +19,7 @@ void UDualShockLibrary::Settings(const FDualShockFeatureReport& Settings)
 bool UDualShockLibrary::InitializeLibrary(const FDeviceContext& Context)
 {
 	HIDDeviceContexts = Context;
+	SetLightbar(FColor::Green, 0.0f, 0.0f);
 	UE_LOG(LogTemp, Log, TEXT("Initializing device model (DualShock 4)"));
 	return true;
 }
@@ -74,7 +75,15 @@ bool UDualShockLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 {
 	if (UDeviceHIDManager::GetDeviceInputState(&HIDDeviceContexts))
 	{
-		const unsigned char* HIDInput = &HIDDeviceContexts.Buffer[1];
+		const unsigned char* HIDInput;
+		if (HIDDeviceContexts.ConnectionType == Bluetooth)
+		{
+			HIDInput = &HIDDeviceContexts.BufferDS4[3];
+		}
+		else
+		{
+			HIDInput = &HIDDeviceContexts.Buffer[1];
+		}
 		
 		// Triggers
 		const bool bLeftTriggerThreshold = HIDInput[0x05] & BTN_LEFT_TRIGGER;

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/FDeviceContext.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/FDeviceContext.h
@@ -59,6 +59,22 @@ struct FDeviceContext
 	 */
 	unsigned char Buffer[78];
 	/**
+	 * @brief Internal data buffer for DualShock 4 Bluetooth communication.
+	 *
+	 * This buffer is specifically allocated for handling input and output data
+	 * when communicating with DualShock 4 controllers connected via Bluetooth.
+	 * It is used in the context of parsing and building device reports during
+	 * Bluetooth transfers, ensuring compliance with the expected report format
+	 * and size required by the DualShock 4 HID protocol.
+	 *
+	 * The buffer size of 547 bytes matches the standard payload requirements
+	 * for DualShock 4 devices in Bluetooth communication scenarios.
+	 *
+	 * @note This buffer is not intended for DualSense controllers or USB connections;
+	 *       for those, use Buffer[78] instead.
+	 */
+	unsigned char BufferDS4[547];
+	/**
 	 * A fixed-size buffer for storing input or output data associated with a device context.
 	 * This buffer is utilized for reading device input reports or for other data
 	 * management tasks. Its size is defined as 78 bytes to accommodate device


### PR DESCRIPTION
Introduces a dedicated 547-byte buffer for DualShock 4 Bluetooth communication in FDeviceContext, updates input/output report handling in DeviceHIDManager to support DualShock 4 over Bluetooth, and adjusts DualShockLibrary to use the correct buffer and offsets. Also improves logging and sets the lightbar color on initialization.