### PR TITLE
Refactor roadmap section in README and clean up device type case

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/rafaelvaloto/WindowsDualsenseUnreal)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/rafaelvaloto/WindowsDualsenseUnreal)
 
----
-
-## 📍 Roadmap
-
-To follow ongoing development and planned features for DualShock and DualSense support, please check our project roadmap:
-
-[🔗 View the Roadmap on GitHub Projects](https://github.com/users/rafaelvaloto/projects/2)
-
----
-
 ### **Plugin with full support for the DualSense PS5 controller in Unreal Engine versions  5.2 ~ 5.6, for Windows platforms. No configuration needed**
 
 ### The controller's customization commands, such as vibration, haptic feedback, and LEDs, can be implemented directly via C++ or Blueprints. Below, we provide examples of both implementations.
@@ -400,7 +390,14 @@ If you want to make the plugin available for all Unreal Engine projects, follow 
 3. **Access the Plugin From Any Project**:
    - Now the plugin is installed globally for all Unreal Engine Version projects. You can enable it in any project directly from the Unreal Editor's **Plugins** menu. 
 
+---
+## 📍 Roadmap
 
+To follow ongoing development and planned features for DualShock and DualSense support, please check our project roadmap:
+
+[🔗 View the Roadmap on GitHub Projects](https://github.com/users/rafaelvaloto/projects/2)
+
+---
 
 ## Contributions
 Thanks to,

--- a/Source/WindowsDualsense_ds5w/Private/Core/DeviceHIDManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DeviceHIDManager.cpp
@@ -99,9 +99,6 @@ bool UDeviceHIDManager::FindDevices(TArray<FDeviceContext>& Devices)
 							case 0x0DF2:
 								Context.DeviceType = Edge;
 								break;
-							case 0x0ce6:
-								Context.DeviceType = Default;
-							break;
 							default: Context.DeviceType = Default;
 						}
 						


### PR DESCRIPTION
Moved the roadmap section in the README for better organization. Removed redundant case for device type 0x0ce6 in DeviceHIDManager.cpp, as it now falls through to the default case.