### PR TITLE
Add copyright and project info headers to source files

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -1,4 +1,6 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright (c) 2025 Rafael Valoto/Publisher. All rights reserved.
+// Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
+// Planned Release Year: 2025
 
 
 #include "Core/DualShock/DualShockLibrary.h"

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -1,4 +1,6 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright (c) 2025 Rafael Valoto/Publisher. All rights reserved.
+// Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
+// Planned Release Year: 2025
 
 
 #include "SonyGamepadProxy.h"

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -1,4 +1,6 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright (c) 2025 Rafael Valoto/Publisher. All rights reserved.
+// Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
+// Planned Release Year: 2025
 
 #pragma once
 

--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -1,4 +1,6 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright (c) 2025 Rafael Valoto/Publisher. All rights reserved.
+// Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
+// Planned Release Year: 2025
 
 #pragma once
 


### PR DESCRIPTION
Replaced placeholder copyright notices with detailed copyright, project, and release year information in DualShockLibrary and SonyGamepadProxy source and header files.