### PR TITLE
Respect EInputDeviceMappingPolicy on UE-5.6+

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DeviceRegistry.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DeviceRegistry.cpp
@@ -88,8 +88,9 @@ void UDeviceRegistry::DetectedChangeConnections(float DeltaTime)
 				{
 					if (Manager->LibraryInstances.Contains(DeviceId))
 					{
-						IPlatformInputDeviceMapper::Get().Internal_ChangeInputDeviceUserMapping(DeviceId, PLATFORMUSERID_NONE, 0);
-						IPlatformInputDeviceMapper::Get().Internal_SetInputDeviceConnectionState(DeviceId, EInputDeviceConnectionState::Invalid);
+						FPlatformUserId OldUser = IPlatformInputDeviceMapper::Get().GetUserForInputDevice(DeviceId);
+						IPlatformInputDeviceMapper::Get().Internal_ChangeInputDeviceUserMapping(DeviceId, PLATFORMUSERID_NONE, OldUser);
+						IPlatformInputDeviceMapper::Get().Internal_SetInputDeviceConnectionState(DeviceId, EInputDeviceConnectionState::Disconnected);
 
 						Manager->RemoveLibraryInstance(DeviceId.GetId());
 						DisconnectedPaths.Add(Path);

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
@@ -691,27 +691,25 @@ void UDualSenseLibrary::StopAll()
 	HidOutput->Feature.VibrationMode = 0xFF;
 	HidOutput->Feature.FeatureMode = 0xF7;
 	HidOutput->PlayerLed.Brightness = 0x00;
-	if (ControllerID == 0 || ControllerID > 3)
-	{
-		HidOutput->Lightbar = {0, 0, 255, 255};
-		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::One);
-	}
+	HidOutput->Lightbar = {0, 0, 255};
 	
-	if (ControllerID == 1)
+	if (ControllerID <= 1)
 	{
-		HidOutput->Lightbar = {255, 0, 0, 255};
-		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::Two);
+		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::One);
 	}
 	
 	if (ControllerID == 2)
 	{
-		HidOutput->Lightbar = {0, 255, 0, 255};
-		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::Three);
+		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::Two);
 	}
 	
 	if (ControllerID == 3)
 	{
-		HidOutput->Lightbar = {255, 255, 255, 255};
+		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::Three);
+	}
+	
+	if (ControllerID >= 4)
+	{
 		HidOutput->PlayerLed.Led = static_cast<unsigned char>(ELedPlayerEnum::All);
 	}
 	SendOut();

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -49,31 +49,12 @@ bool USonyGamepadProxy::DeviceIsConnected(int32 ControllerId)
 	{
 		return false;
 	}
-	
-	ISonyGamepadInterface* Gamepad = UDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
-	if (!Gamepad)
-	{
-		return false;
-	}
-	
-	return true;
-}
 
-bool USonyGamepadProxy::DeviceDisconnect(int32 ControllerId)
-{
-	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
-	if (!DeviceId.IsValid())
+	if (const ISonyGamepadInterface* Gamepad = UDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()); !Gamepad)
 	{
 		return false;
 	}
 	
-	ISonyGamepadInterface* Gamepad = UDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
-	if (!Gamepad)
-	{
-		return true;
-	}
-	
-	Gamepad->Disconnect();
 	return true;
 }
 

--- a/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
@@ -136,7 +136,7 @@ private:
 	 * and platform user IDs. This data structure is used to track the history of devices interacting
 	 * within the system, enabling efficient querying and management of device-user relationships.
 	 */
-	static TMap<FString, TPair<FInputDeviceId, FPlatformUserId>> HistoryDevices;
+	static TMap<FString, FInputDeviceId> HistoryDevices;
 
 	/**
 	 * A static map that maintains active connections by associating unique integer identifiers with their

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/FDeviceContext.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/FDeviceContext.h
@@ -150,20 +150,10 @@ struct FDeviceContext
 	 * enabling seamless interaction and device-specific operations.
 	 */
 	FInputDeviceId UniqueInputDeviceId;
-	/**
-	 * @brief Represents the unique identifier for a platform-specific user.
-	 *
-	 * This variable is used to distinguish and manage users on a specific platform.
-	 * It ensures that user-related data and operations are correctly assigned to the
-	 * appropriate platform user, allowing seamless integration and user management
-	 * in multi-user or multi-platform environments.
-	 */
-	FPlatformUserId UniquePlatformUserId;
 
 	FDeviceContext(): Handle(nullptr), Path{}, Buffer{}, BufferDS4{}, BufferOutput{}, IsConnected(false),
 	                  ConnectionType(), DeviceType(),
-	                  UniqueInputDeviceId(),
-	                  UniquePlatformUserId()
+	                  UniqueInputDeviceId()
 	{
 	}
 };

--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -23,7 +23,6 @@ class WINDOWSDUALSENSE_DS5W_API USonyGamepadProxy : public UObject
 	
 
 public:
-	static FGenericPlatformInputDeviceMapper PlatformInputDeviceMapper;
 	/**
 	 * Checks if the DualSense or DualShock device with the specified Controller ID is connected.
 	 *
@@ -52,16 +51,6 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status")
 	static EDeviceConnection GetConnectionType(int32 ControllerId);
-	/**
-	 * Disconnects the DualSense or DualShock device associated with the given Controller ID.
-	 * This method removes the library instance associated with the specified controller.
-	 *
-	 * @param ControllerId The ID of the DualSense or DualShock or DualShock controller to be disconnected.
-	 * @return true if the disconnection was initiated successfully.
-	 */
-	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status")
-	static bool DeviceDisconnect(int32 ControllerId);
-
 	/**
 	 * Retrieves the battery level of the DualSense or DualShock controller for the specified controller ID.
 	 *
@@ -160,6 +149,19 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status",
 		meta=(DeprecatedFunction, DeprecationMessage="Use GamepadCoOp Plugin"))
 	static bool DeviceReconnect(int32 ControllerId) { return true; }
+
+	/**
+	 * Disconnects the DualSense or DualShock device associated with the given Controller ID.
+	 * This method removes the library instance associated with the specified controller.
+	 *
+	 * @param ControllerId The ID of the DualSense or DualShock or DualShock controller to be disconnected.
+	 * @return true if the disconnection was initiated successfully.
+	 */
+	UE_DEPRECATED(
+		5.1, "Methods refactored and deprecated as of plugin version v1.2.10")
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status",
+		meta=(DeprecatedFunction, DeprecationMessage="SonyGamepad: Dualsense or DualShock Status"))
+	static bool DeviceDisconnect(int32 ControllerId) { return true; };
 
 protected:
 	UFUNCTION()


### PR DESCRIPTION
In Unreal Engine 5.6 a EInputDeviceMappingPolicy policy was introduced. It allows developer to control how devices map to platform users.

This commit calls `IPlatformInputDeviceMapper::GetPlatformUserForNewlyConnectedDevice` to decide which user is assigned to a controller.

For older engines, we still use the logic "if there is only one controller, assign it to primary user, otherwise create new user".

Also, use IPlatformInputDeviceMapper::GetUserForInputDevice to recall user id in case device is reconnected instead of storing our own duplicate of device <-> user mapping that can diverge from IPlatformInputDeviceMapper.