### PR TITLE
Fix errors/warnings when controller is disconnected

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/HIDDeviceInfo.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/HIDDeviceInfo.cpp
@@ -8,8 +8,6 @@
 #include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
 #include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
 
-TMap<FInputDeviceId, EPollResult> FHIDDeviceInfo::PollResults;
-
 void FHIDDeviceInfo::Detect(TArray<FDeviceContext>& Devices)
 {
 	GUID HidGuid;
@@ -244,8 +242,7 @@ void FHIDDeviceInfo::InvalidateHandle(FDeviceContext* Context)
 		ZeroMemory(Context->BufferDS4, sizeof(Context->BufferDS4));
 		ZeroMemory(Context->BufferOutput, sizeof(Context->BufferOutput));
 
-		PollResults.Remove(Context->UniqueInputDeviceId);
-		UE_LOG(LogTemp, Warning, TEXT("HIDManager: Invalidate Handle."));
+		UE_LOG(LogTemp, Log, TEXT("HIDManager: Invalidate Handle."));
 	}
 }
 
@@ -284,8 +281,8 @@ EPollResult FHIDDeviceInfo::PollTick(HANDLE Handle, BYTE* Buffer, DWORD Length, 
 	if (!ReadFile(Handle, Buffer, Length, &OutBytesRead, nullptr))
 	{
 		const DWORD Error = GetLastError();
-		if (ShouldTreatAsDisconnected(Error)) {
-			InvalidateHandle(Handle);
+		if (ShouldTreatAsDisconnected(Error))
+		{
 			return EPollResult::Disconnected;
 		}
 

--- a/Source/WindowsDualsense_ds5w/Private/Core/HIDPollingRunnable.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/HIDPollingRunnable.cpp
@@ -44,7 +44,7 @@ uint32 FHIDPollingRunnable::Run()
 		DWORD LastError = ERROR_SUCCESS;
 		if (!FHIDDeviceInfo::PingOnce(DeviceHandle, &LastError) && FHIDDeviceInfo::ShouldTreatAsDisconnected(LastError))
 		{
-			UE_LOG(LogTemp, Warning, TEXT("Ping failed: device is no longer connected. Shutting down the ping"));
+			UE_LOG(LogTemp, Log, TEXT("Ping failed: device is no longer connected. Shutting down the ping"));
 			return 1;
 		}
 

--- a/Source/WindowsDualsense_ds5w/Public/Core/HIDDeviceInfo.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/HIDDeviceInfo.h
@@ -146,14 +146,4 @@ public:
 			return false;
 		}
 	}
-
-	/**
-	 * @brief Represents the association of input device IDs with their respective polling results and states.
-	 *
-	 * This map associates each input device identifier with a pair consisting of its polling result status
-	 * and the current state of the polling process. It provides a comprehensive overview of the interaction
-	 * outcomes and states for each device during input polling iterations.
-	 */
-private:
-	static TMap<FInputDeviceId, EPollResult> PollResults;
 };


### PR DESCRIPTION
1. FHIDDeviceInfo was calling CloseHandle twice, resulting in exception inside CloseHandle (can be observed if debugger is attached to UE when controller is disconnected)
2. Reduce log verbosity in FHIDDeviceInfo::InvalidateHandle and FHIDPollingRunnable::Run. It is absolutely normal that controller is disconnected, it is not a warning