### PR TITLE
Remove unused include from SonyGamepadProxy.h

### DIFF
--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -8,7 +8,6 @@
 #include "UObject/Object.h"
 #include "Core/Enums/EDeviceCommons.h"
 #include "Core/Enums/EDeviceConnection.h"
-#include "Windows/WindowsApplication.h"
 #include "SonyGamepadProxy.generated.h"
 
 


### PR DESCRIPTION
With this include, we're getting error when trying to include `SonyGamepadProxy.h` in our game code on UE-5.6:

```
C:\UnrealEngine\Engine\Source\Runtime\Core\Public\Windows\AllowWindowsPlatformTypes.h(15,22): fatal error C1189: #error:  Nesting AllowWindowsPlatformTypes.h is not allowed!
	#error Nesting AllowWindowsPlatformTypes.h is not allowed!
	                    ^
```