### PR TITLE
Fix wrong gamepad lookup in USonyGamepadProxy::GetGamepadInterface / DeviceManager::GetGamepadInterface

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DeviceRegistry.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DeviceRegistry.cpp
@@ -136,19 +136,18 @@ FDeviceRegistry::~FDeviceRegistry()
 	}
 }
 
-ISonyGamepadInterface* FDeviceRegistry::GetLibraryInstance(int32 ControllerId)
+ISonyGamepadInterface* FDeviceRegistry::GetLibraryInstance(const FInputDeviceId& DeviceId)
 {
-	const FInputDeviceId GamepadId = FInputDeviceId::CreateFromInternalId(ControllerId);
-	if (!LibraryInstances.Contains(GamepadId))
+	if (!LibraryInstances.Contains(DeviceId))
 	{
 		return nullptr;
 	}
 
-	if (!LibraryInstances[GamepadId]->IsConnected())
+	if (!LibraryInstances[DeviceId]->IsConnected())
 	{
 		return nullptr;
 	}
-	return LibraryInstances[GamepadId];
+	return LibraryInstances[DeviceId];
 }
 
 void FDeviceRegistry::RemoveLibraryInstance(int32 ControllerId)

--- a/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
@@ -44,7 +44,7 @@ void DeviceManager::Tick(float DeltaTime)
 	
 	for (const FInputDeviceId& Device : OutInputDevices)
 	{
-		if (ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(Device.GetId()); Gamepad)
+		if (ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(Device); Gamepad)
 		{
 			const FPlatformUserId UserId = IPlatformInputDeviceMapper::Get().GetUserForInputDevice(Device);
 			if (const int32 ControllerId = FPlatformMisc::GetUserIndexForPlatformUser(UserId); ControllerId == -1)
@@ -86,7 +86,7 @@ void DeviceManager::SetDeviceProperty(int32 ControllerId, const FInputDeviceProp
 			return;
 		}
 		
-		ISonyGamepadTriggerInterface* GamepadTrigger = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+		ISonyGamepadTriggerInterface* GamepadTrigger = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 		if (!IsValid(GamepadTrigger->_getUObject()))
 		{
 			return;
@@ -105,7 +105,7 @@ void DeviceManager::SetHapticFeedbackValues(const int32 ControllerId, const int3
 		return;
 	}
 
-	ISonyGamepadTriggerInterface* GamepadTrigger = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* GamepadTrigger = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!IsValid(GamepadTrigger->_getUObject()))
 	{
 		return;
@@ -124,7 +124,7 @@ void DeviceManager::SetChannelValues(int32 ControllerId, const FForceFeedbackVal
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -143,7 +143,7 @@ void DeviceManager::SetLightColor(const int32 ControllerId, const FColor Color)
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -162,7 +162,7 @@ void DeviceManager::ResetLightColor(const int32 ControllerId)
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -194,16 +194,16 @@ void DeviceManager::OnUserLoginChangedEvent(bool bLoggedIn, int32 UserId, int32 
 FInputDeviceId DeviceManager::GetGamepadInterface(int32 ControllerId)
 {
 	TArray<FInputDeviceId> Devices;
-	Devices.Reset();
 	
 	IPlatformInputDeviceMapper::Get().GetAllInputDevicesForUser(FPlatformUserId::CreateFromInternalId(ControllerId), Devices);
 	
-	for (int32 i = 0; i < Devices.Num(); i++)
+	for (const FInputDeviceId& DeviceId : Devices)
 	{
-		if (ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(i))
+		if (FDeviceRegistry::Get()->GetLibraryInstance(DeviceId))
 		{
-			return Gamepad->GetDeviceId();
+			return DeviceId;
 		}
 	}
+
 	return FInputDeviceId::CreateFromInternalId(INDEX_NONE);
 } 

--- a/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
@@ -19,7 +19,7 @@ void UDualSenseProxy::DeviceSettings(int32 ControllerId, FDualSenseFeatureReport
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -41,7 +41,7 @@ void UDualSenseProxy::LedPlayerEffects(int32 ControllerId, ELedPlayerEnum Value,
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -68,7 +68,7 @@ void UDualSenseProxy::SetVibrationFromAudio(
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -96,7 +96,7 @@ void UDualSenseProxy::SetFeedback(int32 ControllerId, int32 BeginStrength,
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -117,7 +117,7 @@ void UDualSenseProxy::Resistance(int32 ControllerId, int32 StartPosition, int32 
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -138,7 +138,7 @@ void UDualSenseProxy::AutomaticGun(int32 ControllerId, int32 BeginStrength, int3
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -158,7 +158,7 @@ void UDualSenseProxy::ContinuousResistance(int32 ControllerId, int32 StartPositi
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -182,7 +182,7 @@ void UDualSenseProxy::Galloping(
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -205,7 +205,7 @@ void UDualSenseProxy::Machine(int32 ControllerId, int32 StartPosition, int32 End
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -227,7 +227,7 @@ void UDualSenseProxy::Weapon(int32 ControllerId, int32 StartPosition, int32 EndP
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -250,7 +250,7 @@ void UDualSenseProxy::Bow(int32 ControllerId, int32 StartPosition, int32 EndPosi
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -267,7 +267,7 @@ void UDualSenseProxy::NoResistance(int32 ControllerId, EControllerHand Hand)
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -284,7 +284,7 @@ void UDualSenseProxy::StopTriggerEffect(const int32 ControllerId, EControllerHan
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -301,7 +301,7 @@ void UDualSenseProxy::StopAllTriggersEffects(const int32 ControllerId)
 		return;
 	}
 	
-	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId()));
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 	if (!Gamepad)
 	{
 		return;
@@ -318,7 +318,7 @@ void UDualSenseProxy::ResetEffects(const int32 ControllerId)
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -16,7 +16,7 @@ EDeviceType USonyGamepadProxy::GetDeviceType(int32 ControllerId)
 		return EDeviceType::NotFound;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return EDeviceType::NotFound;
@@ -33,7 +33,7 @@ EDeviceConnection USonyGamepadProxy::GetConnectionType(int32 ControllerId)
 		return EDeviceConnection::Unrecognized;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return EDeviceConnection::Unrecognized;
@@ -50,7 +50,7 @@ bool USonyGamepadProxy::DeviceIsConnected(int32 ControllerId)
 		return false;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return false;
@@ -67,7 +67,7 @@ float USonyGamepadProxy::LevelBatteryDevice(int32 ControllerId)
 		return 0.0f;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return 0.0f;
@@ -84,7 +84,7 @@ void USonyGamepadProxy::LedColorEffects(int32 ControllerId, FColor Color, float 
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -101,7 +101,7 @@ void USonyGamepadProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -118,7 +118,7 @@ void USonyGamepadProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -135,7 +135,7 @@ void USonyGamepadProxy::EnableAccelerometerValues(int32 ControllerId, bool bEnab
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -152,7 +152,7 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 		return;
 	}
 	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId.GetId());
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
@@ -164,16 +164,16 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 FInputDeviceId USonyGamepadProxy::GetGamepadInterface(int32 ControllerId)
 {
 	TArray<FInputDeviceId> Devices;
-	Devices.Reset();
 	
 	IPlatformInputDeviceMapper::Get().GetAllInputDevicesForUser(FPlatformUserId::CreateFromInternalId(ControllerId), Devices);
 	
-	for (int32 i = 0; i < Devices.Num(); i++)
+	for (const FInputDeviceId& DeviceId : Devices)
 	{
-		if (ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(i))
+		if (FDeviceRegistry::Get()->GetLibraryInstance(DeviceId))
 		{
-			return Gamepad->GetDeviceId();
+			return DeviceId;
 		}
 	}
+
 	return FInputDeviceId::CreateFromInternalId(INDEX_NONE);
 }

--- a/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
@@ -54,7 +54,7 @@ public:
 	 * @return A pointer to the ISonyGamepadInterface instance corresponding to the specified
 	 *         controller ID, or nullptr if no matching instance exists.
 	 */
-	ISonyGamepadInterface* GetLibraryInstance(int32 ControllerId);
+	ISonyGamepadInterface* GetLibraryInstance(const FInputDeviceId& DeviceId);
 	/**
 	 * Retrieves the map of allocated device library instances. This map associates unique integer
 	 * keys with instances implementing the Sony gamepad interface, allowing access to the currently


### PR DESCRIPTION
The problem was that these methods were using array *index* as device id.

To prevent similar issues in the future, improve type-safety of FDeviceRegistry::GetLibraryInstance, so it is impossible to pass it something that is not a device id

----

Before this PR:

```cpp
	for (int32 i = 0; i < Devices.Num(); i++)
	{
		if (ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(i)) <--------- Attention! i is index. But it is interpreted as device id
		{
			return Gamepad->GetDeviceId();
		}
	}
```