### PR TITLE
Fix/gyro

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -12,11 +12,6 @@
 #include "Core/PlayStationOutputComposer.h"
 #include "Core/Structs/FOutputContext.h"
 
-void UDualShockLibrary::Disconnect()
-{
-	HIDDeviceContexts.IsConnected = false;
-}
-
 void UDualShockLibrary::Settings(const FSettings<FFeatureReport>& Settings)
 {
 }
@@ -28,7 +23,7 @@ void UDualShockLibrary::Settings(const FDualShockFeatureReport& Settings)
 bool UDualShockLibrary::InitializeLibrary(const FDeviceContext& Context)
 {
 	HIDDeviceContexts = Context;
-	SetLightbar(FColor::Green, 0.0f, 0.0f);
+	SetLightbar(FColor::Blue, 0.0f, 0.0f);
 	return true;
 }
 
@@ -220,19 +215,14 @@ void UDualShockLibrary::SetMicrophoneLed(ELedMicEnum Led)
 {
 }
 
-void UDualShockLibrary::SetTouch(const bool bIsTouch)
+void UDualShockLibrary::EnableTouch(const bool bIsTouch)
 {
-	EnableTouch = bIsTouch;
+	bEnableTouch = bIsTouch;
 }
 
-void UDualShockLibrary::SetAcceleration(bool bIsAccelerometer)
+void UDualShockLibrary::EnableMotionSensor(bool bIsMotionSensor)
 {
-	EnableAccelerometerAndGyroscope = bIsAccelerometer;
-}
-
-void UDualShockLibrary::SetGyroscope(bool bIsGyroscope)
-{
-	EnableAccelerometerAndGyroscope = bIsGyroscope;
+	EnableAccelerometerAndGyroscope = bIsMotionSensor;
 }
 
 void UDualShockLibrary::StopAll()

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -111,7 +111,7 @@ void USonyGamepadProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
 	Gamepad->SetMicrophoneLed(Value);
 }
 
-void USonyGamepadProxy::StartMotionSensorCalibration(int32 ControllerId, float Duration)
+void USonyGamepadProxy::StartMotionSensorCalibration(int32 ControllerId, float Duration, float DeadZone)
 {
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -124,7 +124,7 @@ void USonyGamepadProxy::StartMotionSensorCalibration(int32 ControllerId, float D
 	{
 		return;
 	}
-	Gamepad->StartMotionSensorCalibration(Duration);
+	Gamepad->StartMotionSensorCalibration(Duration, DeadZone);
 }
 
 bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, float& Progress)
@@ -143,7 +143,6 @@ bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, flo
 
 	if (UDualSenseLibrary* DsLibrary  = Cast<UDualSenseLibrary>(Gamepad))
 	{
-		UE_LOG(LogTemp, Error, TEXT("Cast DS Library true"));
 		DsLibrary->GetMotionSensorCalibrationStatus(Progress);
 		if (Progress >= 1.0f)
 		{
@@ -151,7 +150,6 @@ bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, flo
 		}
 		return true;
 	}
-	UE_LOG(LogTemp, Error, TEXT("Cast DS Library false"));
 	return false;
 }
 
@@ -185,6 +183,8 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 	{
 		return;
 	}
+
+	
 
 	Gamepad->EnableMotionSensor(bEnableGyroscope);
 }

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -6,6 +6,7 @@
 #include "SonyGamepadProxy.h"
 #include "Misc/CoreDelegates.h"
 #include "Core/DeviceRegistry.h"
+#include "Core/DualSense/DualSenseLibrary.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
 
 EDeviceType USonyGamepadProxy::GetDeviceType(int32 ControllerId)
@@ -110,6 +111,50 @@ void USonyGamepadProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
 	Gamepad->SetMicrophoneLed(Value);
 }
 
+void USonyGamepadProxy::StartMotionSensorCalibration(int32 ControllerId, float Duration)
+{
+	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
+	if (!DeviceId.IsValid())
+	{
+		return;
+	}
+	
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	Gamepad->StartMotionSensorCalibration(Duration);
+}
+
+bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, float& Progress)
+{
+	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
+	if (!DeviceId.IsValid())
+	{
+		return false;
+	}
+	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
+	if (!Gamepad)
+	{
+		UE_LOG(LogTemp, Error, TEXT("Gamepad not found"));
+		return false;
+	}
+
+	if (UDualSenseLibrary* DsLibrary  = Cast<UDualSenseLibrary>(Gamepad))
+	{
+		UE_LOG(LogTemp, Error, TEXT("Cast DS Library true"));
+		DsLibrary->GetMotionSensorCalibrationStatus(Progress);
+		if (Progress >= 1.0f)
+		{
+			return false;
+		}
+		return true;
+	}
+	UE_LOG(LogTemp, Error, TEXT("Cast DS Library false"));
+	return false;
+}
+
 void USonyGamepadProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
 {
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
@@ -124,24 +169,7 @@ void USonyGamepadProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
 		return;
 	}
 
-	Gamepad->SetTouch(bEnableTouch);
-}
-
-void USonyGamepadProxy::EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer)
-{
-	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
-	if (!DeviceId.IsValid())
-	{
-		return;
-	}
-	
-	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
-	if (!Gamepad)
-	{
-		return;
-	}
-
-	Gamepad->SetAcceleration(bEnableAccelerometer);
+	Gamepad->EnableTouch(bEnableTouch);
 }
 
 void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGyroscope)
@@ -158,7 +186,7 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 		return;
 	}
 
-	Gamepad->SetGyroscope(bEnableGyroscope);
+	Gamepad->EnableMotionSensor(bEnableGyroscope);
 }
 
 FInputDeviceId USonyGamepadProxy::GetGamepadInterface(int32 ControllerId)

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -49,7 +49,7 @@ struct FTouchPoint1
 	 * @note Ensure that the value assigned to `X` is valid and adheres
 	 * to the expected data type or constraints for its proper usage.
 	 */
-	unsigned char X;
+	uint16_t X;
 	/**
 	 * @brief Computes the factorial of a given non-negative integer.
 	 *
@@ -63,7 +63,7 @@ struct FTouchPoint1
 	 * @return The factorial of the input number. If the input is 0, returns 1.
 	 * @throw std::invalid_argument If the input is a negative number.
 	 */
-	unsigned char Y;
+	uint16_t Y;
 	/**
 	 * @brief Represents a downward movement in a grid or coordinate system.
 	 *
@@ -115,7 +115,7 @@ struct FTouchPoint2
 	 * @note Ensure proper initialization and context-specific usage of X to avoid
 	 * unintended behaviors.
 	 */
-	unsigned char X;
+	uint16_t X;
 	/**
 	 * @brief Represents a variable 'Y' with unspecified type and purpose.
 	 *
@@ -124,7 +124,7 @@ struct FTouchPoint2
 	 * type, purpose, and usage of 'Y' is undefined and should be interpreted based on
 	 * its associated logic or framework.
 	 */
-	unsigned char Y;
+	uint16_t Y;
 	/**
 	 * @brief Represents a direction or movement towards a lower position or level.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -244,6 +244,40 @@ struct FGyro
 	int16_t Z;
 };
 
+USTRUCT()
+struct FSensorBounds
+{
+	GENERATED_BODY()
+	
+	UPROPERTY()
+	FVector2D Gyro_X_Bounds; // X = Min, Y = Max
+	
+	UPROPERTY()
+	FVector2D Gyro_Y_Bounds; // X = Min, Y = Max
+	
+	UPROPERTY()
+	FVector2D Gyro_Z_Bounds; // X = Min, Y = Max
+	
+	UPROPERTY()
+	FVector2D Accel_X_Bounds; // X = Min, Y = Max
+	
+	UPROPERTY()
+	FVector2D Accel_Y_Bounds; // X = Min, Y = Max
+	
+	UPROPERTY()
+	FVector2D Accel_Z_Bounds; // X = Min, Y = Max
+
+	FSensorBounds()
+	{
+		Gyro_X_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+		Gyro_Y_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+		Gyro_Z_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+		Accel_X_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+		Accel_Y_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+		Accel_Z_Bounds = FVector2D(FLT_MAX, -FLT_MAX);
+	}
+};
+
 /**
  * @class UDualSenseLibrary
  * @brief Utility class for interfacing with the PlayStation DualSense controller.
@@ -667,11 +701,21 @@ public:
 	 */
 	virtual void EnableMotionSensor(bool bIsMotionSensor) override;
 	/**
-	 * Starts the calibration process for the motion sensor of the gamepad.
+	 * @brief Initiates the calibration process for the DualSense motion sensors.
 	 *
-	 * @param Duration The duration for which the calibration should run, in seconds.
+	 * This method starts the calibration routine for the motion sensors in a DualSense controller.
+	 * It collects raw sensor data over the specified duration to determine baseline values and applies
+	 * a dead zone to reduce noise or unintentional drift in sensor readings.
+	 *
+	 * The calibration process allows for improved precision in motion-related computations
+	 * by compensating for sensor drift and other inaccuracies.
+	 *
+	 * @param Duration The duration, in seconds, to collect sensor data for calibration.
+	 *                 Values are clamped between 1.0 and 10.0 seconds.
+	 * @param DeadZone The threshold for sensor dead zone to filter out small motion or drift.
+	 *                 Valid range is from 0.0 to 1.0.
 	 */
-	virtual void StartMotionSensorCalibration(float Duration) override;
+	virtual void StartMotionSensorCalibration(float Duration, float DeadZone) override;
 	/**
 	 * Retrieves the current calibration status of the motion sensors.
 	 *
@@ -774,6 +818,21 @@ private:
 	 * or hardware being used.
 	 */
 	float RightTriggerFeedback;
+	/**
+	 * @variable SensorsDeadZone
+	 * @brief Defines the threshold for ignoring small sensor input variations.
+	 *
+	 * SensorsDeadZone is used to eliminate unintended small variations or noise
+	 * in sensor readings by setting a minimum threshold value. Any input changes
+	 * below this value are considered insignificant and are ignored in further
+	 * processing.
+	 *
+	 * @details This variable is particularly useful for fine-tuning input systems
+	 * to ensure smoother and more reliable sensor-based interactions by reducing
+	 * the sensitivity to unintentional micro-adjustments. It is often applied in
+	 * joystick or motion sensor implementations.
+	 */
+	float SensorsDeadZone = 0.3f;
 	/**
 	 * @variable EnableAccelerometerAndGyroscope
 	 * @brief Flags the activation of accelerometer and gyroscope sensors in the system.
@@ -934,4 +993,6 @@ private:
 	 * accelerometer measurements.
 	 */
 	FVector AccelBaseline;
+
+	FSensorBounds Bounds;
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -164,7 +164,7 @@ struct FAccelerometer
 	/**
 	 *
 	 */
-	unsigned char X;
+	int16_t X;
 	/**
 	 * @brief Represents the variable Y used within the application.
 	 *
@@ -181,7 +181,7 @@ struct FAccelerometer
 	 * Ensure that the value of Y is properly documented and updated
 	 * throughout the codebase to avoid confusion or misuse.
 	 */
-	unsigned char Y;
+	int16_t Y;
 	/**
 	 * @brief Represents a variable named Z.
 	 *
@@ -193,7 +193,7 @@ struct FAccelerometer
 	 * Ensure that the value assigned to Z adheres to the appropriate constraints
 	 * or expectations in the application to maintain correctness and stability.
 	 */
-	unsigned char Z;
+	int16_t Z;
 };
 
 /**
@@ -217,7 +217,7 @@ struct FGyro
 	 * @note Ensure to initialize and manage the value of this variable correctly to avoid
 	 * unexpected behavior or runtime errors.
 	 */
-	unsigned char X;
+	int16_t X;
 	/**
 	 * @brief Represents a generic variable or entity identified as 'Y'.
 	 *
@@ -230,7 +230,7 @@ struct FGyro
 	 *       unexpected behavior. Misuse of 'Y' may lead to runtime errors or
 	 *       logical inconsistencies.
 	 */
-	unsigned char Y;
+	int16_t Y;
 	/**
 	 * @brief Represents a variable or entity denoted as Z.
 	 *
@@ -241,7 +241,7 @@ struct FGyro
 	 * @note The specific use case and type of Z must be determined by its context
 	 *       within the scope of the application or module.
 	 */
-	unsigned char Z;
+	int16_t Z;
 };
 
 /**
@@ -272,7 +272,6 @@ class WINDOWSDUALSENSE_DS5W_API UDualSenseLibrary : public UObject, public ISony
 	GENERATED_BODY()
 	
 public:
-	virtual void Disconnect() override;
 	/**
 	 * @brief Configures device settings for a connected device.
 	 *
@@ -286,40 +285,6 @@ public:
 	 */
 	virtual void Settings(const FSettings<FFeatureReport>& Settings) override;
 	virtual void Settings(const FDualSenseFeatureReport& Settings);
-	/**
-	 * @brief Retrieves the platform user ID associated with the current instance.
-	 *
-	 * This method returns the unique platform-specific user identifier
-	 * associated with a particular user. It provides a way to identify
-	 * and differentiate between users on the platform.
-	 *
-	 * @return The platform user ID as an FPlatformUserId object.
-	 */
-	virtual FPlatformUserId GetUserId() override { return DSUserId; }
-	/**
-	 * @brief Associates a platform user ID with the current instance.
-	 *
-	 * This method is used to assign a specific platform user identifier to the instance,
-	 * allowing the instance to manage or track user-specific operations or settings.
-	 *
-	 * It overrides the base class definition to specifically handle the platform user
-	 * assignment for this implementation.
-	 *
-	 * @param User The platform user identifier to associate with the instance.
-	 */
-	virtual void SetUserId(FPlatformUserId User) override { DSUserId = User; }
-	/**
-	 * Retrieves the unique identifier for the input device.
-	 *
-	 * @return The unique identifier associated with the input device.
-	 */
-	virtual FInputDeviceId GetDeviceId() override { return FInputDeviceId::CreateFromInternalId(ControllerID); };
-	/**
-	 * Sets the device ID for the input device.
-	 *
-	 * @param DeviceId The identifier for the input device to be set.
-	 */
-	virtual void SetDeviceId(FInputDeviceId DeviceId) override {};
 	/**
 	 * @brief Initializes the DualSense library with the specified device context.
 	 *
@@ -628,30 +593,6 @@ public:
 	 */
 	void SetLevelBattery(float Level, bool FullyCharged, bool Charging);
 	/**
-	 * @class UDualSenseLibrary
-	 * @brief Provides functionality for interacting with the DualSense controller's advanced features.
-	 *
-	 * The UDualSenseLibrary class contains methods to enable and manage specific hardware features
-	 * of the DualSense controller, such as accelerometer and gyroscope functionality.
-	 */
-	void SetAcceleration(bool bIsAccelerometer);
-	/**
-	 * @brief Sets the state of the gyroscope functionality.
-	 *
-	 * This method enables or disables the gyroscope functionality in the system based on the passed parameter.
-	 *
-	 * @param bIsGyroscope A boolean value indicating whether to enable or disable the gyroscope.
-	 *                     Pass true to enable the gyroscope or false to disable it.
-	 */
-	void SetGyroscope(bool bIsGyroscope);
-	/**
-	 * Sets the touch functionality state for the DualSense controller.
-	 *
-	 * @param bIsTouch Boolean flag indicating whether the touch functionality should be enabled (true) or disabled (false).
-	 */
-	void SetTouch(bool bIsTouch);
-	
-	/**
 	 * Stops any ongoing adaptive trigger effects on the specified controller hand.
 	 *
 	 * @param Hand The hand for which to stop the adaptive trigger effect.
@@ -691,20 +632,6 @@ public:
 	{
 		return HIDDeviceContexts.ConnectionType;	
 	}
-
-	/**
-	 * @brief Retrieves the device path of the connected HID device.
-	 *
-	 * This function overrides the base class implementation to return the specific
-	 * path associated with the current HID device context. The device path typically
-	 * represents a unique identifier or location that can be used to access the device.
-	 *
-	 * @return A string containing the path of the HID device.
-	 */
-	virtual FString GetDevicePath() override
-	{
-		return HIDDeviceContexts.Path;
-	}
 	/**
 	 * @brief Retrieves the type of device associated with the current context.
 	 *
@@ -718,6 +645,41 @@ public:
 	{
 		return HIDDeviceContexts.DeviceType;	
 	}
+	/**
+	 * @brief Enables or disables the touch functionality for the DualSense library.
+	 *
+	 * This method is used to control whether the touch functionality within
+	 * the DualSense controller is active or inactive. When enabled, touch
+	 * inputs will be processed and can be used in the application.
+	 *
+	 * @param bIsTouch A boolean value that determines the touch functionality state.
+	 *                 Set to true to enable touch or false to disable it.
+	 */
+	virtual void EnableTouch(const bool bIsTouch) override;
+	/**
+	 * @brief Enables or disables the motion sensor feature of the DualSense controller.
+	 *
+	 * This function allows the user to toggle the motion sensor functionality of
+	 * the DualSense controller on or off according to their application's requirements.
+	 *
+	 * @param bIsMotionSensor A boolean value that specifies whether the motion sensor should be enabled (true)
+	 * or disabled (false).
+	 */
+	virtual void EnableMotionSensor(bool bIsMotionSensor) override;
+	/**
+	 * Starts the calibration process for the motion sensor of the gamepad.
+	 *
+	 * @param Duration The duration for which the calibration should run, in seconds.
+	 */
+	virtual void StartMotionSensorCalibration(float Duration) override;
+	/**
+	 * Retrieves the current calibration status of the motion sensors.
+	 *
+	 * @param OutProgress A reference to a float where the current calibration progress will be stored.
+	 *                    The value ranges from 0.0 (no progress) to 1.0 (fully calibrated).
+	 * @return True if the calibration status was successfully retrieved, false otherwise.
+	 */
+	virtual bool GetMotionSensorCalibrationStatus(float& OutProgress) override;
 	/**
 	 * Represents the unique identifier assigned to a specific DualSense controller.
 	 *
@@ -773,7 +735,7 @@ private:
 	 * When set to true, touch input is enabled, allowing the system to respond to touch events.
 	 * When set to false, touch input is disabled, and touch interactions are ignored.
 	 */
-	bool EnableTouch;
+	bool bEnableTouch;
 	/**
 	 * Indicates whether a phone is connected to the system.
 	 *
@@ -824,7 +786,116 @@ private:
 	 * such as gaming controllers, virtual reality devices, or motion-sensing applications.
 	 * Disabling this may reduce resource usage but will disable motion-based features.
 	 */
-	bool EnableAccelerometerAndGyroscope;
+	bool bEnableAccelerometerAndGyroscope;
+	/**
+	 * @brief Indicates the presence of a motion sensor baseline calibration.
+	 *
+	 * The bHasMotionSensorBaseline variable is used to determine whether
+	 * a baseline calibration has been established for the motion sensor.
+	 * This is important for ensuring reliable readings and performance
+	 * from the motion sensor in applications that depend on accurate
+	 * motion or orientation data.
+	 *
+	 * @details A value of true indicates that a baseline is present, suggesting
+	 * that the motion sensor is calibrated and ready for precise operation.
+	 * A value of false indicates that no baseline calibration exists,
+	 * signaling that calibration might be required or motion sensor
+	 * readings could be unreliable.
+	 */
+	bool bHasMotionSensorBaseline;
+	/**
+	 * @brief Indicates whether the system is currently in the process of calibration.
+	 *
+	 * The bIsCalibrating flag is used to track if a calibration operation is active.
+	 * Calibration procedures are often necessary to ensure accurate performance of
+	 * input devices or sensors, and this property serves as a state indicator during
+	 * such processes.
+	 *
+	 * @details While true, the system may be engaged in activities that adjust
+	 * or fine-tune hardware or software settings based on specific calibration data.
+	 * This information can be used to manage or modify application behavior during
+	 * these operations, ensuring no conflicts arise while calibration is underway.
+	 */
+	bool bIsCalibrating;
+	/**
+	 * @var CalibrationStartTime
+	 * @brief Represents the starting time of a calibration process.
+	 *
+	 * This variable is used to store the timestamp indicating when a calibration
+	 * operation begins. It is typically measured in seconds or another relevant
+	 * time unit and functions as a reference point for tracking the duration
+	 * or progress of the calibration procedure.
+	 *
+	 * @details CalibrationStartTime is essential for systems that require precise
+	 * synchronization or monitoring of calibration events. It provides a time
+	 * reference that can be used to evaluate performance, validate timing,
+	 * or manage system states during the calibration process.
+	 */
+	double CalibrationStartTime;
+	/**
+	 * @variable CalibrationDuration
+	 * @brief Specifies the duration required for a calibration process in the system.
+	 *
+	 * The CalibrationDuration variable represents the amount of time, in seconds,
+	 * allocated for completing the calibration procedure of a specific component or
+	 * system. This value can be used to control timing and ensure proper operation
+	 * during the calibration phase.
+	 *
+	 * @details CalibrationDuration plays a crucial role in determining the time
+	 * limits for calibration workflows. It may be configured based on the requirements
+	 * of the specific hardware or software being calibrated. Proper calibration duration
+	 * is essential to achieve accurate results and optimal performance.
+	 */
+	float CalibrationDuration;
+	/**
+	 * @class AccumulatedGyro
+	 * @brief Represents the accumulated gyroscopic sensor data.
+	 *
+	 * The AccumulatedGyro variable is used to store the cumulative measurements
+	 * from a gyroscope over a period of time. Gyroscopic data typically includes
+	 * angular velocity measurements along the X, Y, and Z axes, allowing for
+	 * tracking of rotational motion.
+	 *
+	 * This variable is commonly used in applications requiring precise angular
+	 * motion tracking or orientation changes, such as in controllers, VR/AR
+	 * systems, or robotics.
+	 *
+	 * @details The data stored in AccumulatedGyro may include the sum of angular
+	 * velocities sampled periodically, providing an aggregate measure of
+	 * rotational movement. Proper handling of noise and sensor calibration is
+	 * recommended to ensure accuracy when interpreting this data.
+	 */
+	FVector AccumulatedGyro;
+	/**
+	 * @class AccumulatedAccel
+	 * @brief Represents the total accumulated acceleration vector.
+	 *
+	 * AccumulatedAccel is a variable intended to store the cumulative acceleration
+	 * values detected over time in the form of a 3D vector. This data is typically
+	 * used to track movement or behavior in applications requiring motion detection
+	 * or spatial calculations.
+	 *
+	 * @details The variable holds acceleration data along the X, Y, and Z axes,
+	 * aggregated over a period. It can be utilized in scenarios such as
+	 * gesture recognition, motion analysis, or input handling in systems that
+	 * rely on accelerometer-based data or similar sensors.
+	 */
+	FVector AccumulatedAccel;
+	/**
+	 * @brief Specifies the number of calibration samples to be collected.
+	 *
+	 * CalibrationSampleCount is an integer variable that determines the quantity of
+	 * samples required for calibration in a given process or system. Increasing or
+	 * decreasing this value directly impacts the precision and accuracy of the calibration
+	 * process, as more samples generally provide more statistically significant data,
+	 * while fewer samples may reduce processing time.
+	 *
+	 * @details This variable is utilized in scenarios where data consistency, error
+	 * adjustment, or parameter tuning is needed for optimal functionality. It plays
+	 * a critical role in applications involving sensors, devices, or systems requiring
+	 * initialization or recalibration during operation.
+	 */
+	int32 CalibrationSampleCount;
 	/**
 	 * @brief Represents the context of a Human Interface Device (HID) used by DualSense controllers.
 	 *
@@ -834,4 +905,33 @@ private:
 	 * initialization, input handling, and managing device-specific settings.
 	 */
 	FDeviceContext HIDDeviceContexts;
+	/**
+	 * @variable GyroBaseline
+	 * @brief Represents the baseline gyroscope values for calibration or adjustment.
+	 *
+	 * The GyroBaseline vector is used to store the initial or default calibration values
+	 * of the gyroscope sensor. These baseline values can be used to correct or offset
+	 * the raw gyroscope data to account for systematic errors or biases in measurements.
+	 *
+	 * @details This variable typically holds three-dimensional vector data, representing
+	 * the x, y, and z axes of the gyroscope readings. By subtracting or adjusting against
+	 * these baseline values, the system can improve the accuracy of motion detection,
+	 * ensuring that small deviations or imperfections in the gyroscope's output are compensated for.
+	 */
+	FVector GyroBaseline;
+	/**
+	 * @variable AccelBaseline
+	 * @brief Represents the baseline accelerometer values for calibration or reference purposes.
+	 *
+	 * The AccelBaseline variable is used to store the baseline or default accelerometer readings
+	 * that can serve as a reference point for motion detection or comparison. It is typically
+	 * initialized during a calibration phase and helps in determining deviations or changes in
+	 * the accelerometer data during device movement.
+	 *
+	 * @details This variable generally consists of three components corresponding to the x, y,
+	 * and z axes of acceleration. It is useful in systems that involve sensor input for motion
+	 * tracking, providing a stable reference to identify movement patterns or biases in the
+	 * accelerometer measurements.
+	 */
+	FVector AccelBaseline;
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -209,11 +209,17 @@ public:
 	 */
 	virtual void EnableMotionSensor(bool bIsMotionSensor) override;
 	/**
-	 * Starts the calibration process for the motion sensor of the gamepad.
+	 * @brief Initiates the calibration process for the motion sensor.
 	 *
-	 * @param Duration The duration for which the calibration should run, in seconds.
+	 * This method triggers the calibration sequence for the motion sensor
+	 * to improve its accuracy and responsiveness. Calibration adjusts for
+	 * external factors and ensures stable performance of the sensor.
+	 *
+	 * @param Duration The duration of the calibration process in seconds.
+	 * @param DeadZone The threshold value to filter minor unintended movements
+	 * during calibration.
 	 */
-	virtual void StartMotionSensorCalibration(float Duration) override {}
+	virtual void StartMotionSensorCalibration(float Duration, float DeadZone) override {}
 	/**
 	 * Retrieves the current calibration status of the motion sensors.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -20,7 +20,6 @@ class WINDOWSDUALSENSE_DS5W_API UDualShockLibrary : public UObject, public ISony
 	GENERATED_BODY()
 
 public:
-	virtual void Disconnect() override;
 	/**
 	 * @brief Configures device settings for a connected device.
 	 *
@@ -34,40 +33,6 @@ public:
 	 */
 	virtual void Settings(const FSettings<FFeatureReport>& Settings) override;
 	virtual void Settings(const FDualShockFeatureReport& Settings);
-	/**
-	 * @brief Retrieves the platform user ID associated with the current instance.
-	 *
-	 * This method returns the unique platform-specific user identifier
-	 * associated with a particular user. It provides a way to identify
-	 * and differentiate between users on the platform.
-	 *
-	 * @return The platform user ID as an FPlatformUserId object.
-	 */
-	virtual FPlatformUserId GetUserId() override { return DSUserId; }
-	/**
-	 * @brief Associates a platform user ID with the current instance.
-	 *
-	 * This method is used to assign a specific platform user identifier to the instance,
-	 * allowing the instance to manage or track user-specific operations or settings.
-	 *
-	 * It overrides the base class definition to specifically handle the platform user
-	 * assignment for this implementation.
-	 *
-	 * @param User The platform user identifier to associate with the instance.
-	 */
-	virtual void SetUserId(FPlatformUserId User) override { DSUserId = User; }
-	/**
-	 * Retrieves the unique identifier for the input device.
-	 *
-	 * @return The unique identifier associated with the input device.
-	 */
-	virtual FInputDeviceId GetDeviceId() override { return FInputDeviceId::CreateFromInternalId(ControllerID); };
-	/**
-	 * Sets the device ID for the input device.
-	 *
-	 * @param DeviceId The identifier for the input device to be set.
-	 */
-	virtual void SetDeviceId(FInputDeviceId DeviceId) override {};
 	/**
 	 * @brief Initializes the DualSense library with the specified device context.
 	 *
@@ -149,11 +114,6 @@ public:
 	 */
 	virtual void UpdateInput(const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler,
 	                         const FPlatformUserId UserId, const FInputDeviceId InputDeviceId) override;
-
-	virtual FString GetDevicePath() override
-	{
-		return HIDDeviceContexts.Path;
-	}
 	/**
 	 * Retrieves the current battery level of the DualSense controller.
 	 *
@@ -182,23 +142,6 @@ public:
 	 * @param Led The desired state of the microphone LED, represented by ELedMicEnum.
 	 */
 	virtual void SetMicrophoneLed(ELedMicEnum Led) override;
-	/**
-	 * Sets the touch state for the device.
-	 *
-	 * @param bIsTouch A boolean indicating whether touch input is enabled (true) or disabled (false).
-	 */
-	virtual void SetTouch(const bool bIsTouch) override;
-	/**
-	 * Sets the acceleration mode for the gamepad.
-	 *
-	 * @param bIsAccelerometer If true, enables accelerometer-based input; otherwise, disables it.
-	 */
-	virtual void SetAcceleration(bool bIsAccelerometer) override;
-	/**
-	 * Enables or disables the gyroscope functionality in the gamepad.
-	 * @param bIsGyroscope Indicates whether the gyroscope should be enabled (true) or disabled (false).
-	 */
-	virtual void SetGyroscope(bool bIsGyroscope) override;
 	/**
 	 * Stops all currently active operations or actions associated with the interface.
 	 * This method must be implemented by any derived class to handle the termination
@@ -254,6 +197,32 @@ public:
 		return HIDDeviceContexts.DeviceType;	
 	}
 	/**
+	 * Sets the touch state for the device.
+	 *
+	 * @param bIsTouch A boolean indicating whether touch input is enabled (true) or disabled (false).
+	 */
+	virtual void EnableTouch(const bool bIsTouch) override;
+	/**
+	 * Enables the motion sensor functionality of the gamepad.
+	 *
+	 * @param bIsMotionSensor Specifies whether to enable the gyroscope (true) or accelerometer (false) as the motion sensor.
+	 */
+	virtual void EnableMotionSensor(bool bIsMotionSensor) override;
+	/**
+	 * Starts the calibration process for the motion sensor of the gamepad.
+	 *
+	 * @param Duration The duration for which the calibration should run, in seconds.
+	 */
+	virtual void StartMotionSensorCalibration(float Duration) override {}
+	/**
+	 * Retrieves the current calibration status of the motion sensors.
+	 *
+	 * @param OutProgress A reference to a float where the current calibration progress will be stored.
+	 *                    The value ranges from 0.0 (no progress) to 1.0 (fully calibrated).
+	 * @return True if the calibration status was successfully retrieved, false otherwise.
+	 */
+	virtual bool GetMotionSensorCalibrationStatus(float& OutProgress) override {return false;}
+	/**
 	 * Represents the unique identifier assigned to a specific DualSense controller.
 	 *
 	 * This variable is used to differentiate connected DualSense controllers, enabling the system
@@ -298,7 +267,6 @@ protected:
 	 */
 	static FGenericPlatformInputDeviceMapper PlatformInputDeviceMapper;
 private:
-	FPlatformUserId DSUserId;
 	/**
 	 * @brief Represents the current battery level of a device.
 	 *
@@ -313,7 +281,7 @@ private:
 	 * When set to true, touch input is enabled, allowing the system to respond to touch events.
 	 * When set to false, touch input is disabled, and touch interactions are ignored.
 	 */
-	bool EnableTouch;
+	bool bEnableTouch;
 	/**
 	 * @variable EnableAccelerometerAndGyroscope
 	 * @brief Flags the activation of accelerometer and gyroscope sensors in the system.

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
@@ -39,17 +39,7 @@ class WINDOWSDUALSENSE_DS5W_API ISonyGamepadInterface
 {
 	GENERATED_BODY()
 
-
-	/**
-	 * Retrieves an instance of the Sony gamepad interface.
-	 *
-	 * @return A pointer to the ISonyGamepadInterface instance.
-	 */
 public:
-	/**
-	 * Disconnects the gamepad from the system.
-	 */
-	virtual void Disconnect() = 0;
 	/**
 	 * Pure virtual function that checks the connection status of the gamepad.
 	 *
@@ -57,45 +47,11 @@ public:
 	 */
 	virtual bool IsConnected() = 0;
 	/**
-	 * Retrieves the platform user identifier associated with the current gamepad.
-	 *
-	 * @return The unique platform user ID for the gamepad.
-	 */
-	virtual FPlatformUserId GetUserId() = 0;
-	/**
-	 * Retrieves the unique identifier for the input device.
-	 *
-	 * @return The unique identifier associated with the input device.
-	 */
-	virtual FInputDeviceId GetDeviceId() = 0;
-	/**
-	 * Sets the user ID associated with the platform user.
-	 *
-	 * @param User The platform user ID to associate.
-	 */
-	virtual void SetUserId(FPlatformUserId User) = 0;
-	/**
-	 * Sets the device ID for the input device.
-	 *
-	 * @param DeviceId The identifier for the input device to be set.
-	 */
-	virtual void SetDeviceId(FInputDeviceId DeviceId) = 0;
-	/**
 	 * Sets the identifier for the controller to associate it with a specific device or context.
 	 *
 	 * @param ControllerId An integer representing the unique identifier for the controller.
 	 */
 	virtual void SetControllerId(int32 ControllerId) = 0;
-	/**
-	 * Pure virtual function that must be implemented by derived classes.
-	 * Used to attempt reconnection with the associated Sony gamepad device.
-	 * Typically, the implementation should ensure the gamepad is reconnected
-	 * and restored to its operational state.
-	 *
-	 * This function is expected to be executed when the connection to the gamepad
-	 * has been lost or is in a disconnected state.
-	 */
-	virtual FString GetDevicePath() = 0;
 	/**
 	 * Retrieves the type of the device.
 	 *
@@ -172,18 +128,27 @@ public:
 	 *
 	 * @param bIsTouch A boolean indicating whether touch input is enabled (true) or disabled (false).
 	 */
-	virtual void SetTouch(const bool bIsTouch) = 0;
+	virtual void EnableTouch(const bool bIsTouch) = 0;
 	/**
-	 * Sets the acceleration mode for the gamepad.
+	 * Enables the motion sensor functionality of the gamepad.
 	 *
-	 * @param bIsAccelerometer If true, enables accelerometer-based input; otherwise, disables it.
+	 * @param bIsMotionSensor Specifies whether to enable the gyroscope (true) or accelerometer (false) as the motion sensor.
 	 */
-	virtual void SetAcceleration(bool bIsAccelerometer) = 0;
+	virtual void EnableMotionSensor(bool bIsMotionSensor) = 0;
 	/**
-	 * Enables or disables the gyroscope functionality in the gamepad.
-	 * @param bIsGyroscope Indicates whether the gyroscope should be enabled (true) or disabled (false).
+	 * Starts the calibration process for the motion sensor of the gamepad.
+	 *
+	 * @param Duration The duration for which the calibration should run, in seconds.
 	 */
-	virtual void SetGyroscope(bool bIsGyroscope) = 0;
+	virtual void StartMotionSensorCalibration(float Duration) = 0;
+	/**
+	 * Retrieves the current calibration status of the motion sensors.
+	 *
+	 * @param OutProgress A reference to a float where the current calibration progress will be stored.
+	 *                    The value ranges from 0.0 (no progress) to 1.0 (fully calibrated).
+	 * @return True if the calibration status was successfully retrieved, false otherwise.
+	 */
+	virtual bool GetMotionSensorCalibrationStatus(float& OutProgress) = 0;
 	/**
 	 * Stops all currently active operations or actions associated with the interface.
 	 * This method must be implemented by any derived class to handle the termination

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
@@ -136,11 +136,12 @@ public:
 	 */
 	virtual void EnableMotionSensor(bool bIsMotionSensor) = 0;
 	/**
-	 * Starts the calibration process for the motion sensor of the gamepad.
+	 * Initiates the calibration process for the motion sensor on the gamepad.
 	 *
-	 * @param Duration The duration for which the calibration should run, in seconds.
+	 * @param Duration The duration, in seconds, for which the calibration process should run.
+	 * @param DeadZone The threshold value to be used for filtering out small movements.
 	 */
-	virtual void StartMotionSensorCalibration(float Duration) = 0;
+	virtual void StartMotionSensorCalibration(float Duration, float DeadZone) = 0;
 	/**
 	 * Retrieves the current calibration status of the motion sensors.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -87,13 +87,23 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Led Effects")
 	static void LedMicEffects(int32 ControllerId, ELedMicEnum Value);
 	/**
-	 * Initiates the calibration process for the motion sensor of the specified controller.
+	 * Initiates the motion sensor calibration process for the specified controller.
+	 * The calibration adjusts the motion sensor sensitivity and dead zone settings.
 	 *
-	 * @param ControllerId The ID of the controller whose motion sensor calibration is to be started.
-	 * @param Duration The duration in seconds for the calibration process.
+	 * @param ControllerId The ID of the controller to be calibrated.
+	 * @param Duration The duration of the calibration process in seconds.
+	 * @param DeadZone The sensitivity threshold below which motion input will be ignored.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
-	static void StartMotionSensorCalibration(int32 ControllerId, float Duration = 2.0f);
+	static void StartMotionSensorCalibration(
+		int32 ControllerId,
+		UPARAM(DisplayName = "Calibration Duration (Seconds)", meta = (ClampMin = "1.0", ClampMax = "10.0", UIMin = "1.0", UIMax = "10.0", 
+			ToolTip = "The time in seconds to collect sensor data for calculating the stable center (baseline). Longer durations can provide a more accurate baseline."))
+			float Duration = 2.0f,
+			UPARAM(DisplayName = "Noise Deadzone Percentage", meta = (ClampMin = "0.0", ClampMax = "1.0", UIMin = "0.0", UIMax = "1.0", 
+				ToolTip = "A percentage (0.0 to 1.0) of the sensor noise range to ignore after calibration. A higher value creates a larger deadzone, filtering out more residual noise but potentially ignoring very subtle movements."))
+				float DeadZone = 0.5f
+			);
 	/**
 	 * Retrieves the calibration status of the motion sensor for the specified controller.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -78,7 +78,6 @@ public:
 		UPARAM(DisplayName = "(DualShock 4) Toggle transition time min: 0.0f max: 2.5f",  meta = (ClampMin = "0.0", ClampMax = "2.5", UIMin = "0.0", UIMax = "2.5", ToolTip = "(DualShock) Toggle transition time, in seconds."))
 		const float ToogleTime = 0.0f
 	);
-
 	/**
 	 * Controls the LED and microphone visual effects on a DualSense controller.
 	 *
@@ -87,39 +86,39 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Led Effects")
 	static void LedMicEffects(int32 ControllerId, ELedMicEnum Value);
-
+	/**
+	 * Initiates the calibration process for the motion sensor of the specified controller.
+	 *
+	 * @param ControllerId The ID of the controller whose motion sensor calibration is to be started.
+	 * @param Duration The duration in seconds for the calibration process.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
+	static void StartMotionSensorCalibration(int32 ControllerId, float Duration = 2.0f);
+	/**
+	 * Retrieves the calibration status of the motion sensor for the specified controller.
+	 *
+	 * @param ControllerId The ID of the controller whose motion sensor calibration status is being queried.
+	 * @param Progress A reference to a variable where the calibration progress will be stored, expressed as a percentage.
+	 * @return True if the calibration process is in progress, false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
+	static bool GetMotionSensorCalibrationStatus(int32 ControllerId, float& Progress);
 	/**
 	 * Enables or disables the touch functionality on a specified DualSense controller.
 	 *
 	 * @param ControllerId The identifier of the controller for which the touch functionality should be enabled or disabled.
 	 * @param bEnableTouch A boolean indicating whether to enable (true) or disable (false) the touch functionality.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Touch, Gyroscope and Accelerometer")
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Touch")
 	static void EnableTouch(int32 ControllerId, bool bEnableTouch);
-
-	/**
-	 * Enables or disables accelerometer values for the specified controller.
-	 *
-	 * This method allows toggling the accelerometer functionality for a given
-	 * controller ID. If the DualSense instance for the specified controller ID
-	 * is not available, the function will return without performing any actions.
-	 *
-	 * @param ControllerId The ID of the controller for which the accelerometer values will be enabled or disabled.
-	 * @param bEnableAccelerometer A boolean value that determines whether to enable or disable accelerometer values.
-	 */
-	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Touch, Gyroscope and Accelerometer")
-	static void EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer);
-
 	/**
 	 * Enables or disables the gyroscope functionality for a specified DualSense controller.
 	 *
 	 * @param ControllerId The ID of the controller for which the gyroscope functionality is to be modified.
 	 * @param bEnableGyroscope Set to true to enable the gyroscope, or false to disable it.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock or Touch, Gyroscope and Accelerometer")
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
 	static void EnableGyroscopeValues(int32 ControllerId, bool bEnableGyroscope);
-
-
 	/**
 	 * Remaps the specified gamepad ID to a new user and updates the old user's settings accordingly.
 	 *
@@ -162,6 +161,24 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status",
 		meta=(DeprecatedFunction, DeprecationMessage="SonyGamepad: Dualsense or DualShock Status"))
 	static bool DeviceDisconnect(int32 ControllerId) { return true; };
+
+	/**
+	 * Enables or disables accelerometer values for the specified controller.
+	 *
+	 * This method allows toggling the accelerometer functionality for a given
+	 * controller ID. If the DualSense instance for the specified controller ID
+	 * is not available, the function will return without performing any actions.
+	 *
+	 * @param ControllerId The ID of the controller for which the accelerometer values will be enabled or disabled.
+	 * @param bEnableAccelerometer A boolean value that determines whether to enable or disable accelerometer values.
+	 */
+	UE_DEPRECATED(
+		5.1, "Methods refactored and deprecated as of plugin version v1.2.14")
+	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Touch, Use EnableGyroscopeValues")
+	static void EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer)
+	{
+		EnableGyroscopeValues(ControllerId, bEnableAccelerometer);
+	}
 
 protected:
 	UFUNCTION()


### PR DESCRIPTION
Adds a new Blueprint-callable function, StartMotionSensorCalibration, to nullify the inherent bias and drift from the DualSense motion sensors.

The function works by averaging sensor readings over a user-defined duration to establish a stable baseline. This baseline is then subtracted from all real-time data. An optional deadzone percentage can be applied to filter out residual noise, providing a clean and stable input suitable for gyro aiming.