### PR TITLE
Update includes and version for Unreal plugin

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/HapticsRegistry.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/HapticsRegistry.cpp
@@ -3,6 +3,8 @@
 // Planned Release Year: 2025
 
 #include "../../Public/Core/HapticsRegistry.h"
+#include "Misc/App.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "AudioDevice.h"
 
 TSharedPtr<FHapticsRegistry> FHapticsRegistry::Instance;

--- a/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
@@ -9,10 +9,6 @@
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
 #include "Misc/CoreDelegates.h"
 
-#if PLATFORM_WINDOWS
-#include "Windows/WindowsApplication.h"
-#endif
-
 DeviceManager::DeviceManager(
 	const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler
 	): MessageHandler(InMessageHandler)

--- a/Source/WindowsDualsense_ds5w/Public/Core/HapticsRegistry.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/HapticsRegistry.h
@@ -4,6 +4,11 @@
 
 #pragma once
 #include "Containers/Ticker.h"
+#include "CoreMinimal.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/Guid.h"
+#include "Templates/SharedPointer.h"
+#include "Engine/Engine.h"
 #include "Subsystems/AudioHapticsListener.h"
 
 class FHapticsRegistry final : public TSharedFromThis<FHapticsRegistry>, public FNoncopyable

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Subsystems/AudioHapticsListener.h"
 #include "UObject/Interface.h"
 #include "Templates/SharedPointer.h"
 #include "SonyGamepadTriggerInterface.generated.h"

--- a/Source/WindowsDualsense_ds5w/Public/Subsystems/AudioHapticsListener.h
+++ b/Source/WindowsDualsense_ds5w/Public/Subsystems/AudioHapticsListener.h
@@ -7,7 +7,7 @@
 #include "CoreMinimal.h"
 #include "AudioResampler.h"
 #include "ISubmixBufferListener.h"
-#include "Core/Interfaces/SonyGamepadTriggerInterface.h"
+#include "Containers/Queue.h"
 #include "Core/Structs/FDeviceContext.h"
 
 /**

--- a/WindowsDualsense_ds5w.uplugin
+++ b/WindowsDualsense_ds5w.uplugin
@@ -1,6 +1,6 @@
 {
   "FileVersion": 3,
-  "VersionName": "1.2.19",
+  "VersionName": "1.2.20",
   "FriendlyName": "WindowsDualsense_ds5w",
   "Description": "DualSense & DualShock 4 devices for Unreal Engine platforms. Supports settings of triggers, force feedback, vibrations, leds, battery level, microphone",
   "Category": "Input Devices",


### PR DESCRIPTION
Added missing includes to HapticsRegistry and AudioHapticsListener headers for improved compatibility. Removed unnecessary include from SonyGamepadTriggerInterface. Updated plugin version to 1.2.20.