### PR TITLE
Fix memory corruption in IPlatformInputDeviceMapper

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
@@ -47,7 +47,7 @@ bool UDualSenseLibrary::InitializeLibrary(const FDeviceContext& Context)
 void UDualSenseLibrary::ShutdownLibrary()
 {
 	ButtonStates.Reset();
-	FPlayStationOutputComposer::FreeContext(&HIDDeviceContexts);
+	IPlatformHardwareInfoInterface::Get().InvalidateHandle(&HIDDeviceContexts);
 }
 
 bool UDualSenseLibrary::IsConnected()

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -30,7 +30,7 @@ bool UDualShockLibrary::InitializeLibrary(const FDeviceContext& Context)
 void UDualShockLibrary::ShutdownLibrary()
 {
 	ButtonStates.Reset();
-	FPlayStationOutputComposer::FreeContext(&HIDDeviceContexts);
+	IPlatformHardwareInfoInterface::Get().InvalidateHandle(&HIDDeviceContexts);
 }
 
 bool UDualShockLibrary::IsConnected()

--- a/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Windows/WindowsDeviceInfo.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Windows/WindowsDeviceInfo.cpp
@@ -8,8 +8,6 @@
 #include <hidsdi.h>
 #include <setupapi.h>
 
-#include "Core/PlayStationOutputComposer.h"
-
 void FWindowsDeviceInfo::Detect(TArray<FDeviceContext>& Devices)
 {
 	GUID HidGuid;
@@ -140,7 +138,6 @@ void FWindowsDeviceInfo::Read(FDeviceContext* Context)
 	
 	if (!Context->IsConnected)
 	{
-		InvalidateHandle(Context);
 		UE_LOG(LogTemp, Error, TEXT("Dualsense: DeviceContext->Connected, false"));
 		return;
 	}
@@ -148,11 +145,7 @@ void FWindowsDeviceInfo::Read(FDeviceContext* Context)
 	const size_t InputBufferSize = Context->ConnectionType == Bluetooth ? 78 : 64;
 	HidD_FlushQueue(Context->Handle);
 	DWORD BytesRead = 0;
-	const EPollResult Response = PollTick(Context->Handle, Context->Buffer, InputBufferSize, BytesRead);
-	if (Response == EPollResult::Disconnected)
-	{
-		InvalidateHandle(Context);
-	}
+	PollTick(Context->Handle, Context->Buffer, InputBufferSize, BytesRead);
 }
 
 void FWindowsDeviceInfo::Write(FDeviceContext* Context)
@@ -170,18 +163,11 @@ void FWindowsDeviceInfo::Write(FDeviceContext* Context)
 	{
 		UE_LOG(LogTemp, Error, TEXT("Failed to write output report 0x02/0x31 data to device. report %llu error Code: %d"),
 			OutputReportLength, GetLastError());
-		InvalidateHandle(Context);
 	}
 }
 
 bool FWindowsDeviceInfo::CreateHandle(FDeviceContext* DeviceContext)
 {
-	if (DeviceContext->Handle != INVALID_HANDLE_VALUE)
-	{
-		CloseHandle(DeviceContext->Handle);
-		DeviceContext->Handle = INVALID_HANDLE_VALUE;
-	}
-
 	const HANDLE DeviceHandle = CreateFileW(
 			*DeviceContext->Path,
 			GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, NULL, nullptr
@@ -200,12 +186,11 @@ bool FWindowsDeviceInfo::CreateHandle(FDeviceContext* DeviceContext)
 
 void FWindowsDeviceInfo::InvalidateHandle(FDeviceContext* Context)
 {
-	IPlatformInputDeviceMapper::Get().Internal_SetInputDeviceConnectionState(Context->UniqueInputDeviceId, EInputDeviceConnectionState::Disconnected);
 	if (!Context)
 	{
 		return;
 	}
-	
+
 	if (Context->Handle != INVALID_HANDLE_VALUE)
 	{
 		CloseHandle(Context->Handle);
@@ -237,13 +222,7 @@ EPollResult FWindowsDeviceInfo::PollTick(HANDLE Handle, unsigned char* Buffer, i
 	OutBytesRead = 0;
 	if (!ReadFile(Handle, Buffer, Length, &OutBytesRead, nullptr))
 	{
-		const int32 Error = GetLastError();
-		if (ShouldTreatAsDisconnected(Error))
-		{
-			return EPollResult::Disconnected;
-		}
-
-		InvalidateHandle(Handle);
+		return EPollResult::Disconnected;
 	}
 
 	return EPollResult::ReadOk;

--- a/Source/WindowsDualsense_ds5w/Private/Core/PlayStationOutputComposer.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/PlayStationOutputComposer.cpp
@@ -9,11 +9,6 @@
 
 const uint32 FPlayStationOutputComposer::CRCSeed = 0xeada2d49;
 
-void FPlayStationOutputComposer::FreeContext(FDeviceContext* Context)
-{
-	IPlatformHardwareInfoInterface::Get().InvalidateHandle(Context);
-}
-
 void FPlayStationOutputComposer::OutputDualShock(FDeviceContext* DeviceContext)
 {
 	const FOutputContext* HidOut = &DeviceContext->Output;

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -185,6 +185,9 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 
 FInputDeviceId USonyGamepadProxy::GetGamepadInterface(int32 ControllerId)
 {
+	// We should never call into IPlatformInputDeviceMapper from non-game thread because it is not thread-safe
+	check(IsInGameThread());
+
 	TArray<FInputDeviceId> Devices;
 	
 	IPlatformInputDeviceMapper::Get().GetAllInputDevicesForUser(FPlatformUserId::CreateFromInternalId(ControllerId), Devices);

--- a/Source/WindowsDualsense_ds5w/Public/Core/PlayStationOutputComposer.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/PlayStationOutputComposer.h
@@ -47,17 +47,6 @@ public:
 	 */
 	const static uint32 HashTable[256];
 	/**
-	 * @fn FPlayStationOutputComposer::FreeContext(FDeviceContext* Context)
-	 *
-	 * Releases and invalidates the provided device context, ensuring that
-	 * all associated resources are properly disposed of or reset. This method
-	 * guarantees that the device handle referenced by the context becomes
-	 * unusable after execution to prevent unauthorized or unintended access.
-	 *
-	 * @param Context The device context to be freed and invalidated. Must not be null.
-	 */
-	static void FreeContext(FDeviceContext* Context);
-	/**
 	 * @brief Configures and sends output data to a DualSense device using the provided device context.
 	 *
 	 * This method builds and formats an output data buffer with specific device settings,


### PR DESCRIPTION
The issue is that IPlatformInputDeviceMapper is not thread-safe. However, WindowsDualsenseUnreal calls it from multiple threads, most notably when gamepad is unplugged.

This commit
1. Adds checks that IPlatformInputDeviceMapper is only accessed from game thread
2. Reworks device disconnect handling so it is only done from game thread (through `FDeviceRegistry::RemoveLibraryInstance`)