### PR TITLE
Fix inability to depend on WindowsDualsenseUnreal from game module

### DIFF
--- a/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
+++ b/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
@@ -19,7 +19,7 @@ public class WindowsDualsense_ds5w : ModuleRules
 		
 		if (Target.Platform == UnrealTargetPlatform.Win64)
 		{
-		    PublicAdditionalLibraries.Add("hid.lib");
+			PublicSystemLibraries.Add("hid.lib");
 		}
 	    
 		if (Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.Mac)


### PR DESCRIPTION
There is an issue with dependency on `hid.lib`:

```
Library 'hid.lib' was not resolvable to a file when used in Module 'WindowsDualsense_ds5w', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning.
```