### PR TITLE
Remove controller event dispatch logic and deadzone changes

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualSense/DualSenseLibrary.cpp
@@ -85,13 +85,11 @@ void UDualSenseLibrary::CheckButtonInput(const TSharedRef<FGenericApplicationMes
 	const bool PreviousState = ButtonStates.Contains(ButtonName) ? ButtonStates[ButtonName] : false;
 	if (IsButtonPressed && !PreviousState)
 	{
-		SetControllerEvents(true);
 		InMessageHandler.Get().OnControllerButtonPressed(ButtonName, UserId, InputDeviceId, false);
 	}
 
 	if (!IsButtonPressed && PreviousState)
 	{
-		SetControllerEvents(true);
 		InMessageHandler.Get().OnControllerButtonReleased(ButtonName, UserId, InputDeviceId, false);
 	}
 
@@ -106,24 +104,23 @@ void UDualSenseLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 	{
 		IPlatformHardwareInfoInterface::Get().Read(NewContext);
 	});
-
-	// FValidateHelpers::PrintBufferAsHex(HIDDeviceContexts.Buffer, 78, TEXT(""));
+	
 	const size_t Padding = HIDDeviceContexts.ConnectionType == Bluetooth ? 2 : 1;
 	const unsigned char* HIDInput = &HIDDeviceContexts.Buffer[Padding];
 
-	const float LeftAnalogX = static_cast<char>(static_cast<short>(HIDInput[0x00] - 128));
-	const float LeftAnalogY = static_cast<char>(static_cast<short>(HIDInput[0x01] - 127) * -1);
+	const float LeftAnalogX = static_cast<int8_t>(HIDInput[0x00] - 128);
+	const float LeftAnalogY = static_cast<int8_t>(HIDInput[0x01] - 128) * -1.0f;
 	InMessageHandler.Get().OnControllerAnalog(FGamepadKeyNames::LeftAnalogX, UserId, InputDeviceId,
-	                                          LeftAnalogX / 128.0f);
+											  LeftAnalogX / 128.0f);
 	InMessageHandler.Get().OnControllerAnalog(FGamepadKeyNames::LeftAnalogY, UserId, InputDeviceId,
-	                                          LeftAnalogY / 128.0f);
+											  LeftAnalogY / 128.0f);
 
-	const float RightAnalogX = static_cast<char>(static_cast<short>(HIDInput[0x02] - 128));
-	const float RightAnalogY = static_cast<char>(static_cast<short>(HIDInput[0x03] - 127) * -1);
+	const float RightAnalogX = static_cast<int8_t>(HIDInput[0x02] - 128);
+	const float RightAnalogY = static_cast<int8_t>(HIDInput[0x03] - 128) * -1.0f;
 	InMessageHandler.Get().OnControllerAnalog(FGamepadKeyNames::RightAnalogX, UserId, InputDeviceId,
-	                                          RightAnalogX / 128.0f);
+											  RightAnalogX / 128.0f);
 	InMessageHandler.Get().OnControllerAnalog(FGamepadKeyNames::RightAnalogY, UserId, InputDeviceId,
-	                                          RightAnalogY / 128.0f);
+											  RightAnalogY / 128.0f);
 
 	const float TriggerL = HIDInput[0x04] / 256.0f;
 	const float TriggerR = HIDInput[0x05] / 256.0f;
@@ -239,7 +236,6 @@ void UDualSenseLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 	// mapped urenal native gamepad Start and Select
 	CheckButtonInput(InMessageHandler, UserId, InputDeviceId, FGamepadKeyNames::SpecialRight, Start);
 	CheckButtonInput(InMessageHandler, UserId, InputDeviceId, FGamepadKeyNames::SpecialLeft, Select);
-
 
 	const bool bLeftTriggerThreshold = HIDInput[0x08] & BTN_LEFT_TRIGGER;
 	const bool bRightTriggerThreshold = HIDInput[0x08] & BTN_RIGHT_TRIGGER;
@@ -430,7 +426,6 @@ void UDualSenseLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 		// converted from raw counts to SI using the official DS constants.
 		// The Madgwick instance and initialization are static locals so that
 		// we don't need to change the class header right away.
-
 		static FMadgwickAhrs MadgwickFilter(200.0f, 0.08f);
 		static bool bMadgwickInitialized = false;
 

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -52,13 +52,11 @@ void UDualShockLibrary::CheckButtonInput(const TSharedRef<FGenericApplicationMes
 	const bool PreviousState = ButtonStates.Contains(ButtonName) ? ButtonStates[ButtonName] : false;
 	if (IsButtonPressed && !PreviousState)
 	{
-		SetControllerEvents(true);
 		InMessageHandler.Get().OnControllerButtonPressed(ButtonName, UserId, InputDeviceId, false);
 	}
 
 	if (!IsButtonPressed && PreviousState)
 	{
-		SetControllerEvents(true);
 		InMessageHandler.Get().OnControllerButtonReleased(ButtonName, UserId, InputDeviceId, false);
 	}
 

--- a/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
@@ -7,7 +7,6 @@
 #include "Async/TaskGraphInterfaces.h"
 #include "Core/DeviceRegistry.h"
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
-#include "GameFramework/InputDeviceSubsystem.h"
 #include "Misc/CoreDelegates.h"
 
 DeviceManager::DeviceManager(
@@ -64,11 +63,6 @@ void DeviceManager::Tick(float DeltaTime)
 
 			FInputDeviceScope InputScope(this, TEXT("DeviceManager.WindowsDualsense"), Device.GetId(), ContextDrive);
 			Gamepad->UpdateInput(MessageHandler, UserId, Device, DeltaTime);
-			if (Gamepad->IsSendControllerEvents())
-			{
-				UInputDeviceSubsystem::Get()->OnInputHardwareDeviceChanged.Broadcast(UserId, Device);
-				Gamepad->SetControllerEvents(false);
-			}
 		}
 	}
 	

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -746,32 +746,6 @@ public:
 	 * It is reset during library shutdown to clear all stored button states.
 	 */
 	TMap<const FName, bool> ButtonStates;
-	/**
-	 * @brief Checks if controller events should be dispatched.
-	 *
-	 * Determines whether the system is configured to send controller
-	 * input events, allowing input processing for connected controllers.
-	 *
-	 * @return A boolean value where true indicates that controller events
-	 * should be sent, and false indicates they should not.
-	 */
-	virtual bool IsSendControllerEvents() override
-	{
-		return IsChange;
-	}
-	/**
-	 * @brief Checks if controller events should be dispatched.
-	 *
-	 * Determines whether the system is configured to send controller
-	 * input events, allowing input processing for connected controllers.
-	 *
-	 * @return A boolean value where true indicates that controller events
-	 * should be sent, and false indicates they should not.
-	 */
-	virtual void SetControllerEvents(const bool IsChanged) override
-	{
-		IsChange = IsChanged;
-	}
 
 protected:
 	/**
@@ -809,7 +783,6 @@ protected:
 	void SetLevelBattery(float Level, bool FullyCharged, bool Charging);
 
 private:
-	bool IsChange = false;
 	/**
 	 * @typedef FPlatformUserId
 	 * @brief Represents a platform-specific user identifier.
@@ -913,7 +886,7 @@ private:
 	 * the sensitivity to unintentional micro-adjustments. It is often applied in
 	 * joystick or motion sensor implementations.
 	 */
-	float SensorsDeadZone = 0.3f;
+	float SensorsDeadZone = 0.0f;
 	/**
 	 * @variable SensorsDeadZone
 	 * @brief Defines the threshold for ignoring small sensor input variations.

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -184,34 +184,6 @@ public:
 		return HIDDeviceContexts.DeviceType;	
 	}
 	/**
-	 * @brief Checks if controller events should be dispatched.
-	 *
-	 * Determines whether the system is configured to send controller
-	 * input events, allowing input processing for connected controllers.
-	 *
-	 * @return A boolean value where true indicates that controller events
-	 * should be sent, and false indicates they should not.
-	 */
-	virtual bool IsSendControllerEvents() override
-	{
-		return IsChange;
-	}
-
-	/**
-	 * @brief Sets the state of controller event handling.
-	 *
-	 * This method updates the controller's event-handling state based on
-	 * the provided input. It can be used to enable or disable the event
-	 * handling mechanism dynamically.
-	 *
-	 * @param IsChanged A boolean value indicating whether the controller
-	 * event state should be updated.
-	 */
-	virtual void SetControllerEvents(const bool IsChanged) override
-	{
-		IsChange = IsChanged;
-	}
-	/**
 	 * Sets the touch state for the device.
 	 *
 	 * @param bIsTouch A boolean indicating whether touch input is enabled (true) or disabled (false).
@@ -296,7 +268,6 @@ protected:
 	 */
 	static FGenericPlatformInputDeviceMapper PlatformInputDeviceMapper;
 private:
-	bool IsChange = false;
 	/**
 	 * @brief Represents the current battery level of a device.
 	 *
@@ -344,7 +315,7 @@ private:
 	 *
 	 * @variable SensorsDeadZone A float representing the dead zone limit for sensor input.
 	 */
-	float SensorsDeadZone = 0.3f;
+	float SensorsDeadZone = 0.0f;
 	/**
 	 * @brief Represents the threshold value to filter out unintended analog stick movements.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
@@ -162,19 +162,6 @@ public:
 	 */
 	virtual FDeviceContext* GetMutableDeviceContext() = 0;
 	/**
-	 * Determines if the controller events are enabled for sending.
-	 *
-	 * @return True if controller events are being sent, false otherwise.
-	 */
-	virtual bool IsSendControllerEvents() = 0;
-	/**
-	 * Sets the controller events based on the specified change state.
-	 *
-	 * @param IsChanged A boolean value indicating whether the controller events have changed.
-	 * @return True if the operation was successful, otherwise false.
-	 */
-	virtual void SetControllerEvents(const bool IsChanged) = 0;
-	/**
 	 * Pure virtual function that sends data or commands to the connected gamepad.
 	 * This function must be implemented by any class inheriting this interface.
 	 */


### PR DESCRIPTION
Eliminated IsSendControllerEvents and SetControllerEvents methods from DualSense and DualShock libraries and their interface, along with related state and event dispatch code. Also set SensorsDeadZone to 0.0f in both libraries. This simplifies input handling and removes unused event broadcasting logic.