### PR TITLE
Introduce codestyle enforced by clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,52 @@
+---
+Language:                                       Cpp
+BasedOnStyle:                                   LLVM
+IndentWidth:                                    4
+TabWidth:                                       4
+UseTab:                                         ForIndentation
+Standard:                                       Cpp11
+FixNamespaceComments:                           true
+NamespaceIndentation:                           All
+AccessModifierOffset:                           -4
+AlignAfterOpenBracket:                          Align
+AlignEscapedNewlines:                           DontAlign
+AlignTrailingComments:                          true
+AllowShortCaseLabelsOnASingleLine:              true
+AllowShortFunctionsOnASingleLine:               InlineOnly
+BreakConstructorInitializersBeforeComma:        true
+RemoveSemicolon: true
+InsertBraces: true
+InsertNewlineAtEOF: true
+
+# We have to to set BeforeLambdaBody = false, because in other case it makes incorrect indention
+BreakBeforeBraces:                              Custom
+
+BraceWrapping:
+  AfterEnum:                                    true
+  AfterStruct:                                  true
+  AfterCaseLabel:                               true
+  AfterClass:                                   true
+  AfterControlStatement:                        Always
+  AfterFunction:                                true
+  AfterNamespace:                               true
+  AfterUnion:                                   true
+  AfterExternBlock:                             true
+  BeforeElse:                                   true
+  BeforeCatch:                                  true
+  SplitEmptyFunction:                           false
+  IndentBraces:                                 false
+
+AllowShortLambdasOnASingleLine:                 Inline
+ColumnLimit:                                    0
+PointerAlignment:                               Left
+SpaceAfterTemplateKeyword:                      false
+SpacesInAngles:                                 false
+ContinuationIndentWidth:                        4
+IndentCaseLabels:                               true
+IncludeBlocks:                                  Merge
+IncludeCategories:
+  - Regex:    '.*\.generated\.h'
+    Priority: 2
+  - Regex:    '.*'
+    Priority: 1
+...

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,8 @@
+name: clang-format
+on: [push, pull_request]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DoozyX/clang-format-lint-action@v0.20

--- a/ClangFormat.sh
+++ b/ClangFormat.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+PROJECT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+NC='\033[0m' # No Color
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+
+function win_setup() {
+	local vswhere
+	vswhere="$(cygpath -u "/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe")"
+
+	if [ ! -f "${vswhere}" ]
+	then
+		printf "${YELLOW}Warning: %s not found${NC}\n" "${vswhere}"
+		return
+	fi
+
+	local clang_format
+	clang_format="$("${vswhere}" -products '*' -latest -find VC/Tools/Llvm/bin/clang-format.exe)"
+
+	local clang_format_dir
+	clang_format_dir="$(cygpath -u "$(dirname "${clang_format}")")"
+	export PATH="${clang_format_dir}:${PATH}"
+}
+
+case "${OSTYPE}" in
+	"darwin"*)
+		function nproc {
+			sysctl -n hw.logicalcpu
+	  	}
+		;;
+	"msys")
+		win_setup
+		;;
+esac
+
+# Print clang-format version so it is visible in CI logs and such
+clang-format --version
+
+find "${PROJECT_DIR}" \( -name "*.h" -o -name "*.cpp" \) -print0 | xargs -0 -P "$(nproc)" -n 100 clang-format -i

--- a/Source/WindowsDualsense_ds5w/Private/Core/Algorithms/MadgwickAhrs.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/Algorithms/MadgwickAhrs.cpp
@@ -1,49 +1,74 @@
 ﻿
 #include "Core/Algorithms/MadgwickAhrs.h"
 
-FMadgwickAhrs::FMadgwickAhrs ( const float SampleFreq , const float Beta ): Beta(Beta), SampleFreq(SampleFreq),
-                                                                            q0(1.0f), q1(0.0f), q2(0.0f), q3(0.0f)
+FMadgwickAhrs::FMadgwickAhrs(const float SampleFreq, const float Beta)
+    : Beta(Beta)
+    , SampleFreq(SampleFreq)
+    , q0(1.0f)
+    , q1(0.0f)
+    , q2(0.0f)
+    , q3(0.0f)
 {}
 
-void FMadgwickAhrs::UpdateImu ( float gx , float gy , float gz , float ax , float ay , float az , float dt )
+void FMadgwickAhrs::UpdateImu(float gx, float gy, float gz, float ax, float ay, float az, float dt)
 {
-	if (dt <= 0.0f) return;
+	if (dt <= 0.0f)
+	{
+		return;
+	}
 	SampleFreq = 0.99f * SampleFreq + 0.01f * (1.0f / dt);
 
 	float q0_ = q0, q1_ = q1, q2_ = q2, q3_ = q3;
 
-	float norm = std::sqrt(ax*ax + ay*ay + az*az);
-	if (norm == 0.0f) return;
-	ax /= norm; ay /= norm; az /= norm;
+	float norm = std::sqrt(ax * ax + ay * ay + az * az);
+	if (norm == 0.0f)
+	{
+		return;
+	}
+	ax /= norm;
+	ay /= norm;
+	az /= norm;
 
 	float _2q0 = 2.0f * q0_, _2q1 = 2.0f * q1_, _2q2 = 2.0f * q2_, _2q3 = 2.0f * q3_;
 	float _4q0 = 4.0f * q0_, _4q1 = 4.0f * q1_, _4q2 = 4.0f * q2_;
 	float _8q1 = 8.0f * q1_, _8q2 = 8.0f * q2_;
-	float q0q0 = q0_*q0_, q1q1 = q1_*q1_, q2q2 = q2_*q2_, q3q3 = q3_*q3_;
+	float q0q0 = q0_ * q0_, q1q1 = q1_ * q1_, q2q2 = q2_ * q2_, q3q3 = q3_ * q3_;
 
 	float s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
 	float s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1_ - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
 	float s2 = 4.0f * q0q0 * q2_ + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
 	float s3 = 4.0f * q1q1 * q3_ - _2q1 * ax + 4.0f * q2q2 * q3_ - _2q2 * ay;
 
-	float s_norm = std::sqrt(s0*s0 + s1*s1 + s2*s2 + s3*s3);
-	if (s_norm == 0.0f) return;
-	s0 /= s_norm; s1 /= s_norm; s2 /= s_norm; s3 /= s_norm;
+	float s_norm = std::sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3);
+	if (s_norm == 0.0f)
+	{
+		return;
+	}
+	s0 /= s_norm;
+	s1 /= s_norm;
+	s2 /= s_norm;
+	s3 /= s_norm;
 
 	float qDot0 = 0.5f * (-q1_ * gx - q2_ * gy - q3_ * gz) - Beta * s0;
-	float qDot1 = 0.5f * ( q0_ * gx + q2_ * gz - q3_ * gy) - Beta * s1;
-	float qDot2 = 0.5f * ( q0_ * gy - q1_ * gz + q3_ * gx) - Beta * s2;
-	float qDot3 = 0.5f * ( q0_ * gz + q1_ * gy - q2_ * gx) - Beta * s3;
+	float qDot1 = 0.5f * (q0_ * gx + q2_ * gz - q3_ * gy) - Beta * s1;
+	float qDot2 = 0.5f * (q0_ * gy - q1_ * gz + q3_ * gx) - Beta * s2;
+	float qDot3 = 0.5f * (q0_ * gz + q1_ * gy - q2_ * gx) - Beta * s3;
 
-	q0_ += qDot0 * dt; q1_ += qDot1 * dt; q2_ += qDot2 * dt; q3_ += qDot3 * dt;
+	q0_ += qDot0 * dt;
+	q1_ += qDot1 * dt;
+	q2_ += qDot2 * dt;
+	q3_ += qDot3 * dt;
 
-	float q_norm = std::sqrt(q0_*q0_ + q1_*q1_ + q2_*q2_ + q3_*q3_);
-	q0 = q0_/q_norm; q1 = q1_/q_norm; q2 = q2_/q_norm; q3 = q3_/q_norm;
+	float q_norm = std::sqrt(q0_ * q0_ + q1_ * q1_ + q2_ * q2_ + q3_ * q3_);
+	q0 = q0_ / q_norm;
+	q1 = q1_ / q_norm;
+	q2 = q2_ / q_norm;
+	q3 = q3_ / q_norm;
 }
 
-void FMadgwickAhrs::GetQuaternion(float &Nq0, float &Nq1, float &Nq2, float &Nq3) const
+void FMadgwickAhrs::GetQuaternion(float& Nq0, float& Nq1, float& Nq2, float& Nq3) const
 {
-	Nq0 = this->q0;  // ou simplesmente q0 = FMadgwickAhrs::q0;
+	Nq0 = this->q0; // ou simplesmente q0 = FMadgwickAhrs::q0;
 	Nq1 = this->q1;
 	Nq2 = this->q2;
 	Nq3 = this->q3;
@@ -51,19 +76,26 @@ void FMadgwickAhrs::GetQuaternion(float &Nq0, float &Nq1, float &Nq2, float &Nq3
 
 void FMadgwickAhrs::Reset()
 {
-	q0 = 1.0f; q1 = 0.0f; q2 = 0.0f; q3 = 0.0f;
+	q0 = 1.0f;
+	q1 = 0.0f;
+	q2 = 0.0f;
+	q3 = 0.0f;
 }
 
-void FMadgwickAhrs::GetEuler ( float & Roll , float & Yaw, float & Pitch )
+void FMadgwickAhrs::GetEuler(float& Roll, float& Yaw, float& Pitch)
 {
-	Roll = std::atan2(2.0f*(q0*q1 + q2*q3), 1.0f - 2.0f*(q1*q1 + q2*q2));
-	const float Sinp = 2.0f*(q0*q2 - q3*q1);
+	Roll = std::atan2(2.0f * (q0 * q1 + q2 * q3), 1.0f - 2.0f * (q1 * q1 + q2 * q2));
+	const float Sinp = 2.0f * (q0 * q2 - q3 * q1);
 	Pitch = (std::fabs(Sinp) >= 1.0f) ? (copysignf(1.5707963f, Sinp)) : std::asin(Sinp);
-	Yaw = std::atan2(2.0f*(q0*q3 + q1*q2), 1.0f - 2.0f*(q2*q2 + q3*q3));
+	Yaw = std::atan2(2.0f * (q0 * q3 + q1 * q2), 1.0f - 2.0f * (q2 * q2 + q3 * q3));
 }
 
-void FMadgwickAhrs::SetBeta ( const float BetaValue )
-{ Beta = BetaValue; }
+void FMadgwickAhrs::SetBeta(const float BetaValue)
+{
+	Beta = BetaValue;
+}
 
-void FMadgwickAhrs::SetSampleFreq ( const float Freq )
-{ SampleFreq = Freq; }
+void FMadgwickAhrs::SetSampleFreq(const float Freq)
+{
+	SampleFreq = Freq;
+}

--- a/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/DualShock/DualShockLibrary.cpp
@@ -2,15 +2,14 @@
 // Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
 // Planned Release Year: 2025
 
-
 #include "Core/DualShock/DualShockLibrary.h"
 #include "Async/Async.h"
 #include "Async/TaskGraphInterfaces.h"
-#include "InputCoreTypes.h"
-#include "Helpers/ValidateHelpers.h"
-#include "Core/PlayStationOutputComposer.h"
 #include "Core/Interfaces/PlatformHardwareInfoInterface.h"
+#include "Core/PlayStationOutputComposer.h"
 #include "Core/Structs/OutputContext.h"
+#include "Helpers/ValidateHelpers.h"
+#include "InputCoreTypes.h"
 
 void UDualShockLibrary::Settings(const FDualShockFeatureReport& Settings)
 {
@@ -67,8 +66,7 @@ void UDualShockLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
                                     const FPlatformUserId UserId, const FInputDeviceId InputDeviceId, float Delta)
 {
 	FDeviceContext* Context = &HIDDeviceContexts;
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [NewContext = MoveTemp(Context)]()
-	{
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [NewContext = MoveTemp(Context)]() {
 		IPlatformHardwareInfoInterface::Get().Read(NewContext);
 	});
 
@@ -138,31 +136,31 @@ void UDualShockLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 
 	switch (HIDInput[0x04] & 0x0F)
 	{
-	case 0x0:
-		ButtonsMask |= BTN_DPAD_UP;
-		break;
-	case 0x4:
-		ButtonsMask |= BTN_DPAD_DOWN;
-		break;
-	case 0x6:
-		ButtonsMask |= BTN_DPAD_LEFT;
-		break;
-	case 0x2:
-		ButtonsMask |= BTN_DPAD_RIGHT;
-		break;
-	case 0x5:
-		ButtonsMask |= BTN_DPAD_LEFT | BTN_DPAD_DOWN;
-		break;
-	case 0x7:
-		ButtonsMask |= BTN_DPAD_LEFT | BTN_DPAD_UP;
-		break;
-	case 0x1:
-		ButtonsMask |= BTN_DPAD_RIGHT | BTN_DPAD_UP;
-		break;
-	case 0x3:
-		ButtonsMask |= BTN_DPAD_RIGHT | BTN_DPAD_DOWN;
-		break;
-	default: ;
+		case 0x0:
+			ButtonsMask |= BTN_DPAD_UP;
+			break;
+		case 0x4:
+			ButtonsMask |= BTN_DPAD_DOWN;
+			break;
+		case 0x6:
+			ButtonsMask |= BTN_DPAD_LEFT;
+			break;
+		case 0x2:
+			ButtonsMask |= BTN_DPAD_RIGHT;
+			break;
+		case 0x5:
+			ButtonsMask |= BTN_DPAD_LEFT | BTN_DPAD_DOWN;
+			break;
+		case 0x7:
+			ButtonsMask |= BTN_DPAD_LEFT | BTN_DPAD_UP;
+			break;
+		case 0x1:
+			ButtonsMask |= BTN_DPAD_RIGHT | BTN_DPAD_UP;
+			break;
+		case 0x3:
+			ButtonsMask |= BTN_DPAD_RIGHT | BTN_DPAD_DOWN;
+			break;
+		default:;
 	}
 	const bool bDPadLeft = ButtonsMask & BTN_DPAD_LEFT;
 	const bool bDPadDown = ButtonsMask & BTN_DPAD_DOWN;
@@ -195,7 +193,6 @@ void UDualShockLibrary::UpdateInput(const TSharedRef<FGenericApplicationMessageH
 	CheckButtonInput(InMessageHandler, UserId, InputDeviceId, FGamepadKeyNames::SpecialRight, Start);
 	CheckButtonInput(InMessageHandler, UserId, InputDeviceId, FGamepadKeyNames::SpecialLeft, Select);
 }
-
 
 void UDualShockLibrary::SetVibration(const FForceFeedbackValues& Values)
 {

--- a/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Commons/CommonsDeviceInfo.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Commons/CommonsDeviceInfo.cpp
@@ -11,8 +11,8 @@
 static const uint16 SONY_VENDOR_ID = 0x054C;
 static const uint16 DUALSHOCK4_PID_V1 = 0x05C4;
 static const uint16 DUALSHOCK4_PID_V2 = 0x09CC;
-static const uint16 DUALSENSE_PID     = 0x0CE6;
-static const uint16 DUALSENSE_EDGE_PID= 0x0DF2;
+static const uint16 DUALSENSE_PID = 0x0CE6;
+static const uint16 DUALSENSE_EDGE_PID = 0x0DF2;
 
 void FCommonsDeviceInfo::Read(FDeviceContext* Context)
 {
@@ -33,7 +33,7 @@ void FCommonsDeviceInfo::Read(FDeviceContext* Context)
 		}
 		return;
 	}
-	
+
 	const size_t InputReportLength = (Context->ConnectionType == Bluetooth) ? 78 : 64;
 	if (sizeof(Context->Buffer) < InputReportLength)
 	{
@@ -88,18 +88,17 @@ void FCommonsDeviceInfo::Detect(TArray<FDeviceContext>& Devices)
 	Devices.Empty();
 
 	const TSet<uint16> SupportedPIDs = {
-		DUALSHOCK4_PID_V1,
-		DUALSHOCK4_PID_V2,
-		DUALSENSE_PID,
-		DUALSENSE_EDGE_PID
-	};
+	    DUALSHOCK4_PID_V1,
+	    DUALSHOCK4_PID_V2,
+	    DUALSENSE_PID,
+	    DUALSENSE_EDGE_PID};
 
 	SDL_hid_device_info* Devs = SDL_hid_enumerate(SONY_VENDOR_ID, 0);
 	if (!Devs)
 	{
 		return;
 	}
-	
+
 	for (SDL_hid_device_info* CurrentDevice = Devs; CurrentDevice != nullptr; CurrentDevice = CurrentDevice->next)
 	{
 		if (SupportedPIDs.Contains(CurrentDevice->product_id))
@@ -107,22 +106,22 @@ void FCommonsDeviceInfo::Detect(TArray<FDeviceContext>& Devices)
 			FDeviceContext NewDeviceContext;
 			FString PathStr = UTF8_TO_TCHAR(CurrentDevice->path);
 			NewDeviceContext.Path = PathStr;
-			
+
 			switch (CurrentDevice->product_id)
 			{
-			case DUALSHOCK4_PID_V1:
-			case DUALSHOCK4_PID_V2:
-				NewDeviceContext.DeviceType = EDeviceType::DualShock4;
-				break;
-			case DUALSENSE_EDGE_PID:
-				NewDeviceContext.DeviceType = EDeviceType::DualSenseEdge;
-				break;
-			case DUALSENSE_PID:
-			default:
-				NewDeviceContext.DeviceType = EDeviceType::DualSense;
-				break;
+				case DUALSHOCK4_PID_V1:
+				case DUALSHOCK4_PID_V2:
+					NewDeviceContext.DeviceType = EDeviceType::DualShock4;
+					break;
+				case DUALSENSE_EDGE_PID:
+					NewDeviceContext.DeviceType = EDeviceType::DualSenseEdge;
+					break;
+				case DUALSENSE_PID:
+				default:
+					NewDeviceContext.DeviceType = EDeviceType::DualSense;
+					break;
 			}
-	
+
 			NewDeviceContext.IsConnected = true;
 			if (CurrentDevice->interface_number == -1)
 			{
@@ -145,14 +144,14 @@ bool FCommonsDeviceInfo::CreateHandle(FDeviceContext* Context)
 	{
 		return false;
 	}
-  
+
 	const FTCHARToUTF8 PathConverter(*Context->Path);
-	const FPlatformDeviceHandle Handle =  SDL_hid_open_path(PathConverter.Get(), true);
+	const FPlatformDeviceHandle Handle = SDL_hid_open_path(PathConverter.Get(), true);
 	if (Handle == INVALID_PLATFORM_HANDLE)
 	{
 		return false;
 	}
-	
+
 	SDL_hid_set_nonblocking(Handle, 1);
 	Context->Handle = Handle;
 	return true;

--- a/Source/WindowsDualsense_ds5w/Private/Core/PlayStationOutputComposer.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/PlayStationOutputComposer.cpp
@@ -2,7 +2,6 @@
 // Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
 // Planned Release Year: 2025
 
-
 #include "Core/PlayStationOutputComposer.h"
 #include "Core/Interfaces/PlatformHardwareInfoInterface.h"
 #include "Core/Structs/DeviceContext.h"
@@ -20,7 +19,7 @@ void FPlayStationOutputComposer::OutputDualShock(FDeviceContext* DeviceContext)
 	{
 		DeviceContext->BufferOutput[1] = 0xc0;
 	}
-	
+
 	unsigned char* Output = &DeviceContext->BufferOutput[Padding];
 
 	if (DeviceContext->ConnectionType == Bluetooth)
@@ -32,7 +31,7 @@ void FPlayStationOutputComposer::OutputDualShock(FDeviceContext* DeviceContext)
 	{
 		Output[0] = 0xff;
 	}
-	
+
 	Output[3 + (Padding - 1)] = HidOut->Rumbles.Left;
 	Output[4 + (Padding - 1)] = HidOut->Rumbles.Right;
 	Output[5 + (Padding - 1)] = HidOut->Lightbar.R;
@@ -63,7 +62,7 @@ void FPlayStationOutputComposer::OutputDualSense(FDeviceContext* DeviceContext)
 	}
 
 	FOutputContext* HidOut = &DeviceContext->Output;
-	unsigned char*  Output = &DeviceContext->BufferOutput[Padding];
+	unsigned char* Output = &DeviceContext->BufferOutput[Padding];
 	Output[0] = HidOut->Feature.VibrationMode;
 	Output[1] = HidOut->Feature.FeatureMode;
 	Output[2] = HidOut->Rumbles.Left;
@@ -91,9 +90,9 @@ void FPlayStationOutputComposer::OutputDualSense(FDeviceContext* DeviceContext)
 	else
 	{
 		SetTriggerEffects(&Output[10], HidOut->RightTrigger);
-		SetTriggerEffects(&Output[21], HidOut->LeftTrigger);	
+		SetTriggerEffects(&Output[21], HidOut->LeftTrigger);
 	}
-	
+
 	if (DeviceContext->ConnectionType == Bluetooth)
 	{
 		const int32 CrcChecksum = Compute(DeviceContext->BufferOutput, 74);
@@ -102,20 +101,20 @@ void FPlayStationOutputComposer::OutputDualSense(FDeviceContext* DeviceContext)
 		DeviceContext->BufferOutput[0x4C] = static_cast<unsigned char>((CrcChecksum & 0x00FF0000) >> 16UL);
 		DeviceContext->BufferOutput[0x4D] = static_cast<unsigned char>((CrcChecksum & 0xFF000000) >> 24UL);
 	}
-	
+
 	IPlatformHardwareInfoInterface::Get().Write(DeviceContext);
 }
 
 void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapticTriggers& Effect)
 {
 	Trigger[0x0] = Effect.Mode;
-	
+
 	if (Effect.Mode == 0x01) // Continuous Resistance
 	{
 		Trigger[0x1] = ((Effect.Strengths.ActiveZones >> 0) & 0xFF);
 		Trigger[0x2] = ((Effect.Strengths.StrengthZones >> 0) & 0xFF);
 	}
-	
+
 	if (Effect.Mode == 0x21) // Resistance
 	{
 		Trigger[0x1] = 0xf0;
@@ -127,7 +126,7 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 		Trigger[0x8] = 0x0;
 		Trigger[0x9] = 0x0;
 	}
-	
+
 	if (Effect.Mode == 0x22 || Effect.Mode == 0x02) // Bow
 	{
 		Trigger[0x1] = Effect.Strengths.Compose[0];
@@ -140,8 +139,7 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 		Trigger[0x8] = 0x0;
 		Trigger[0x9] = 0x0;
 	}
-	
-	
+
 	if (Effect.Mode == 0x23) // Gallopping
 	{
 		Trigger[0x1] = Effect.Strengths.Compose[0];
@@ -154,15 +152,17 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 		Trigger[0x8] = 0x00;
 		Trigger[0x9] = 0x00;
 	}
-	
+
 	if (Effect.Mode == 0x25) // Weapon
 	{
 		Trigger[0x1] = ((Effect.Strengths.ActiveZones >> 0) & 0xFF);
 		Trigger[0x2] = ((Effect.Strengths.ActiveZones >> 8) & 0xFF);
 		for (int i = 0; i < 8; ++i)
+		{
 			Trigger[0x3 + i] = (Effect.Strengths.StrengthZones >> (8 * i)) & 0xFF;
+		}
 	}
-	
+
 	if (Effect.Mode == 0x26) // Automatic Gun
 	{
 		Trigger[0x1] = Effect.Strengths.Compose[0];
@@ -175,21 +175,21 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 		Trigger[0x8] = 0x0;
 		Trigger[0x9] = Effect.Strengths.Compose[9];
 	}
-	
- if (Effect.Mode == 0x27) // Machine Advanced
- {
-     // Structure: [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
-     Trigger[0x1] = Effect.Strengths.Compose[0]; // Start_Zone
-     Trigger[0x2] = Effect.Strengths.Compose[1]; // Behavior_Flag
-     Trigger[0x3] = Effect.Strengths.Compose[2]; // Force_Amplitude
-     Trigger[0x4] = Effect.Strengths.Compose[3]; // Period
-     Trigger[0x5] = Effect.Strengths.Compose[4]; // Frequency
-     Trigger[0x6] = 0x00;
-     Trigger[0x7] = 0x00;
-     Trigger[0x8] = 0x00;
-     Trigger[0x9] = 0x00;
- }
-	
+
+	if (Effect.Mode == 0x27) // Machine Advanced
+	{
+		// Structure: [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
+		Trigger[0x1] = Effect.Strengths.Compose[0]; // Start_Zone
+		Trigger[0x2] = Effect.Strengths.Compose[1]; // Behavior_Flag
+		Trigger[0x3] = Effect.Strengths.Compose[2]; // Force_Amplitude
+		Trigger[0x4] = Effect.Strengths.Compose[3]; // Period
+		Trigger[0x5] = Effect.Strengths.Compose[4]; // Frequency
+		Trigger[0x6] = 0x00;
+		Trigger[0x7] = 0x00;
+		Trigger[0x8] = 0x00;
+		Trigger[0x9] = 0x00;
+	}
+
 	if (Effect.Mode == 0xFF) // Custom Mode effect
 	{
 		Trigger[0x0] = Effect.Strengths.Compose[0];
@@ -203,7 +203,7 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 		Trigger[0x8] = Effect.Strengths.Compose[8];
 		Trigger[0x9] = Effect.Strengths.Compose[9];
 	}
-	
+
 	if (Effect.Mode == 0x0) // Reset
 	{
 		Trigger[0x1] = 0x0;
@@ -220,7 +220,10 @@ void FPlayStationOutputComposer::SetTriggerEffects(unsigned char* Trigger, FHapt
 
 void FPlayStationOutputComposer::SendAudioHapticAdvanced(FDeviceContext* DeviceContext)
 {
-	if (!DeviceContext) return;
+	if (!DeviceContext)
+	{
+		return;
+	}
 
 	if (DeviceContext->ConnectionType == Bluetooth)
 	{
@@ -235,39 +238,38 @@ void FPlayStationOutputComposer::SendAudioHapticAdvanced(FDeviceContext* DeviceC
 }
 
 const uint32 FPlayStationOutputComposer::HashTable[256] = {
-	0xd202ef8d, 0xa505df1b, 0x3c0c8ea1, 0x4b0bbe37, 0xd56f2b94, 0xa2681b02, 0x3b614ab8, 0x4c667a2e,
-	0xdcd967bf, 0xabde5729, 0x32d70693, 0x45d03605, 0xdbb4a3a6, 0xacb39330, 0x35bac28a, 0x42bdf21c,
-	0xcfb5ffe9, 0xb8b2cf7f, 0x21bb9ec5, 0x56bcae53, 0xc8d83bf0, 0xbfdf0b66, 0x26d65adc, 0x51d16a4a,
-	0xc16e77db, 0xb669474d, 0x2f6016f7, 0x58672661, 0xc603b3c2, 0xb1048354, 0x280dd2ee, 0x5f0ae278,
-	0xe96ccf45, 0x9e6bffd3, 0x762ae69, 0x70659eff, 0xee010b5c, 0x99063bca, 0xf6a70, 0x77085ae6,
-	0xe7b74777, 0x90b077e1, 0x9b9265b, 0x7ebe16cd, 0xe0da836e, 0x97ddb3f8, 0xed4e242, 0x79d3d2d4,
-	0xf4dbdf21, 0x83dcefb7, 0x1ad5be0d, 0x6dd28e9b, 0xf3b61b38, 0x84b12bae, 0x1db87a14, 0x6abf4a82,
-	0xfa005713, 0x8d076785, 0x140e363f, 0x630906a9, 0xfd6d930a, 0x8a6aa39c, 0x1363f226, 0x6464c2b0,
-	0xa4deae1d, 0xd3d99e8b, 0x4ad0cf31, 0x3dd7ffa7, 0xa3b36a04, 0xd4b45a92, 0x4dbd0b28, 0x3aba3bbe,
-	0xaa05262f, 0xdd0216b9, 0x440b4703, 0x330c7795, 0xad68e236, 0xda6fd2a0, 0x4366831a, 0x3461b38c,
-	0xb969be79, 0xce6e8eef, 0x5767df55, 0x2060efc3, 0xbe047a60, 0xc9034af6, 0x500a1b4c, 0x270d2bda,
-	0xb7b2364b, 0xc0b506dd, 0x59bc5767, 0x2ebb67f1, 0xb0dff252, 0xc7d8c2c4, 0x5ed1937e, 0x29d6a3e8,
-	0x9fb08ed5, 0xe8b7be43, 0x71beeff9, 0x6b9df6f, 0x98dd4acc, 0xefda7a5a, 0x76d32be0, 0x1d41b76,
-	0x916b06e7, 0xe66c3671, 0x7f6567cb, 0x862575d, 0x9606c2fe, 0xe101f268, 0x7808a3d2, 0xf0f9344,
-	0x82079eb1, 0xf500ae27, 0x6c09ff9d, 0x1b0ecf0b, 0x856a5aa8, 0xf26d6a3e, 0x6b643b84, 0x1c630b12,
-	0x8cdc1683, 0xfbdb2615, 0x62d277af, 0x15d54739, 0x8bb1d29a, 0xfcb6e20c, 0x65bfb3b6, 0x12b88320,
-	0x3fba6cad, 0x48bd5c3b, 0xd1b40d81, 0xa6b33d17, 0x38d7a8b4, 0x4fd09822, 0xd6d9c998, 0xa1def90e,
-	0x3161e49f, 0x4666d409, 0xdf6f85b3, 0xa868b525, 0x360c2086, 0x410b1010, 0xd80241aa, 0xaf05713c,
-	0x220d7cc9, 0x550a4c5f, 0xcc031de5, 0xbb042d73, 0x2560b8d0, 0x52678846, 0xcb6ed9fc, 0xbc69e96a,
-	0x2cd6f4fb, 0x5bd1c46d, 0xc2d895d7, 0xb5dfa541, 0x2bbb30e2, 0x5cbc0074, 0xc5b551ce, 0xb2b26158,
-	0x4d44c65, 0x73d37cf3, 0xeada2d49, 0x9ddd1ddf, 0x3b9887c, 0x74beb8ea, 0xedb7e950, 0x9ab0d9c6,
-	0xa0fc457, 0x7d08f4c1, 0xe401a57b, 0x930695ed, 0xd62004e, 0x7a6530d8, 0xe36c6162, 0x946b51f4,
-	0x19635c01, 0x6e646c97, 0xf76d3d2d, 0x806a0dbb, 0x1e0e9818, 0x6909a88e, 0xf000f934, 0x8707c9a2,
-	0x17b8d433, 0x60bfe4a5, 0xf9b6b51f, 0x8eb18589, 0x10d5102a, 0x67d220bc, 0xfedb7106, 0x89dc4190,
-	0x49662d3d, 0x3e611dab, 0xa7684c11, 0xd06f7c87, 0x4e0be924, 0x390cd9b2, 0xa0058808, 0xd702b89e,
-	0x47bda50f, 0x30ba9599, 0xa9b3c423, 0xdeb4f4b5, 0x40d06116, 0x37d75180, 0xaede003a, 0xd9d930ac,
-	0x54d13d59, 0x23d60dcf, 0xbadf5c75, 0xcdd86ce3, 0x53bcf940, 0x24bbc9d6, 0xbdb2986c, 0xcab5a8fa,
-	0x5a0ab56b, 0x2d0d85fd, 0xb404d447, 0xc303e4d1, 0x5d677172, 0x2a6041e4, 0xb369105e, 0xc46e20c8,
-	0x72080df5, 0x50f3d63, 0x9c066cd9, 0xeb015c4f, 0x7565c9ec, 0x262f97a, 0x9b6ba8c0, 0xec6c9856,
-	0x7cd385c7, 0xbd4b551, 0x92dde4eb, 0xe5dad47d, 0x7bbe41de, 0xcb97148, 0x95b020f2, 0xe2b71064,
-	0x6fbf1d91, 0x18b82d07, 0x81b17cbd, 0xf6b64c2b, 0x68d2d988, 0x1fd5e91e, 0x86dcb8a4, 0xf1db8832,
-	0x616495a3, 0x1663a535, 0x8f6af48f, 0xf86dc419, 0x660951ba, 0x110e612c, 0x88073096, 0xFF000000
-};
+    0xd202ef8d, 0xa505df1b, 0x3c0c8ea1, 0x4b0bbe37, 0xd56f2b94, 0xa2681b02, 0x3b614ab8, 0x4c667a2e,
+    0xdcd967bf, 0xabde5729, 0x32d70693, 0x45d03605, 0xdbb4a3a6, 0xacb39330, 0x35bac28a, 0x42bdf21c,
+    0xcfb5ffe9, 0xb8b2cf7f, 0x21bb9ec5, 0x56bcae53, 0xc8d83bf0, 0xbfdf0b66, 0x26d65adc, 0x51d16a4a,
+    0xc16e77db, 0xb669474d, 0x2f6016f7, 0x58672661, 0xc603b3c2, 0xb1048354, 0x280dd2ee, 0x5f0ae278,
+    0xe96ccf45, 0x9e6bffd3, 0x762ae69, 0x70659eff, 0xee010b5c, 0x99063bca, 0xf6a70, 0x77085ae6,
+    0xe7b74777, 0x90b077e1, 0x9b9265b, 0x7ebe16cd, 0xe0da836e, 0x97ddb3f8, 0xed4e242, 0x79d3d2d4,
+    0xf4dbdf21, 0x83dcefb7, 0x1ad5be0d, 0x6dd28e9b, 0xf3b61b38, 0x84b12bae, 0x1db87a14, 0x6abf4a82,
+    0xfa005713, 0x8d076785, 0x140e363f, 0x630906a9, 0xfd6d930a, 0x8a6aa39c, 0x1363f226, 0x6464c2b0,
+    0xa4deae1d, 0xd3d99e8b, 0x4ad0cf31, 0x3dd7ffa7, 0xa3b36a04, 0xd4b45a92, 0x4dbd0b28, 0x3aba3bbe,
+    0xaa05262f, 0xdd0216b9, 0x440b4703, 0x330c7795, 0xad68e236, 0xda6fd2a0, 0x4366831a, 0x3461b38c,
+    0xb969be79, 0xce6e8eef, 0x5767df55, 0x2060efc3, 0xbe047a60, 0xc9034af6, 0x500a1b4c, 0x270d2bda,
+    0xb7b2364b, 0xc0b506dd, 0x59bc5767, 0x2ebb67f1, 0xb0dff252, 0xc7d8c2c4, 0x5ed1937e, 0x29d6a3e8,
+    0x9fb08ed5, 0xe8b7be43, 0x71beeff9, 0x6b9df6f, 0x98dd4acc, 0xefda7a5a, 0x76d32be0, 0x1d41b76,
+    0x916b06e7, 0xe66c3671, 0x7f6567cb, 0x862575d, 0x9606c2fe, 0xe101f268, 0x7808a3d2, 0xf0f9344,
+    0x82079eb1, 0xf500ae27, 0x6c09ff9d, 0x1b0ecf0b, 0x856a5aa8, 0xf26d6a3e, 0x6b643b84, 0x1c630b12,
+    0x8cdc1683, 0xfbdb2615, 0x62d277af, 0x15d54739, 0x8bb1d29a, 0xfcb6e20c, 0x65bfb3b6, 0x12b88320,
+    0x3fba6cad, 0x48bd5c3b, 0xd1b40d81, 0xa6b33d17, 0x38d7a8b4, 0x4fd09822, 0xd6d9c998, 0xa1def90e,
+    0x3161e49f, 0x4666d409, 0xdf6f85b3, 0xa868b525, 0x360c2086, 0x410b1010, 0xd80241aa, 0xaf05713c,
+    0x220d7cc9, 0x550a4c5f, 0xcc031de5, 0xbb042d73, 0x2560b8d0, 0x52678846, 0xcb6ed9fc, 0xbc69e96a,
+    0x2cd6f4fb, 0x5bd1c46d, 0xc2d895d7, 0xb5dfa541, 0x2bbb30e2, 0x5cbc0074, 0xc5b551ce, 0xb2b26158,
+    0x4d44c65, 0x73d37cf3, 0xeada2d49, 0x9ddd1ddf, 0x3b9887c, 0x74beb8ea, 0xedb7e950, 0x9ab0d9c6,
+    0xa0fc457, 0x7d08f4c1, 0xe401a57b, 0x930695ed, 0xd62004e, 0x7a6530d8, 0xe36c6162, 0x946b51f4,
+    0x19635c01, 0x6e646c97, 0xf76d3d2d, 0x806a0dbb, 0x1e0e9818, 0x6909a88e, 0xf000f934, 0x8707c9a2,
+    0x17b8d433, 0x60bfe4a5, 0xf9b6b51f, 0x8eb18589, 0x10d5102a, 0x67d220bc, 0xfedb7106, 0x89dc4190,
+    0x49662d3d, 0x3e611dab, 0xa7684c11, 0xd06f7c87, 0x4e0be924, 0x390cd9b2, 0xa0058808, 0xd702b89e,
+    0x47bda50f, 0x30ba9599, 0xa9b3c423, 0xdeb4f4b5, 0x40d06116, 0x37d75180, 0xaede003a, 0xd9d930ac,
+    0x54d13d59, 0x23d60dcf, 0xbadf5c75, 0xcdd86ce3, 0x53bcf940, 0x24bbc9d6, 0xbdb2986c, 0xcab5a8fa,
+    0x5a0ab56b, 0x2d0d85fd, 0xb404d447, 0xc303e4d1, 0x5d677172, 0x2a6041e4, 0xb369105e, 0xc46e20c8,
+    0x72080df5, 0x50f3d63, 0x9c066cd9, 0xeb015c4f, 0x7565c9ec, 0x262f97a, 0x9b6ba8c0, 0xec6c9856,
+    0x7cd385c7, 0xbd4b551, 0x92dde4eb, 0xe5dad47d, 0x7bbe41de, 0xcb97148, 0x95b020f2, 0xe2b71064,
+    0x6fbf1d91, 0x18b82d07, 0x81b17cbd, 0xf6b64c2b, 0x68d2d988, 0x1fd5e91e, 0x86dcb8a4, 0xf1db8832,
+    0x616495a3, 0x1663a535, 0x8f6af48f, 0xf86dc419, 0x660951ba, 0x110e612c, 0x88073096, 0xFF000000};
 
 uint32 FPlayStationOutputComposer::Compute(const unsigned char* Buffer, const size_t Len)
 {

--- a/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DeviceManager.cpp
@@ -10,8 +10,8 @@
 #include "Misc/CoreDelegates.h"
 
 DeviceManager::DeviceManager(
-	const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler
-	): MessageHandler(InMessageHandler)
+    const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler)
+    : MessageHandler(InMessageHandler)
 {
 	FCoreDelegates::OnUserLoginChangedEvent.AddRaw(this, &DeviceManager::OnUserLoginChangedEvent);
 }
@@ -23,19 +23,18 @@ DeviceManager::~DeviceManager()
 
 void DeviceManager::SendControllerEvents()
 {
-	
 }
 
 void DeviceManager::Tick(float DeltaTime)
 {
 	FDeviceRegistry::Get()->DetectedChangeConnections(DeltaTime);
-	
+
 	PollAccumulator += DeltaTime;
 	if (PollAccumulator < PollInterval)
 	{
 		return;
 	}
-	
+
 	PollAccumulator = 0.0f;
 
 	TArray<FInputDeviceId> OutInputDevices;
@@ -65,12 +64,14 @@ void DeviceManager::Tick(float DeltaTime)
 			Gamepad->UpdateInput(MessageHandler, UserId, Device, DeltaTime);
 		}
 	}
-	
 }
 
 void DeviceManager::SetDeviceProperty(int32 ControllerId, const FInputDeviceProperty* Property)
 {
-	if (!Property) return;
+	if (!Property)
+	{
+		return;
+	}
 
 	if (Property->Name == "InputDeviceLightColor")
 	{
@@ -85,7 +86,7 @@ void DeviceManager::SetDeviceProperty(int32 ControllerId, const FInputDeviceProp
 		{
 			return;
 		}
-		
+
 		ISonyGamepadTriggerInterface* GamepadTrigger = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
 		if (!IsValid(GamepadTrigger->_getUObject()))
 		{
@@ -109,7 +110,7 @@ void DeviceManager::SetHapticFeedbackValues(const int32 ControllerId, const int3
 	{
 		return;
 	}
-	
+
 	GamepadTrigger->SetHapticFeedback(Hand, &Values);
 }
 
@@ -120,13 +121,13 @@ void DeviceManager::SetChannelValues(int32 ControllerId, const FForceFeedbackVal
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
 	}
-	
+
 	Gamepad->SetVibration(Values);
 }
 
@@ -137,7 +138,7 @@ void DeviceManager::SetLightColor(const int32 ControllerId, const FColor Color)
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -154,13 +155,13 @@ void DeviceManager::ResetLightColor(const int32 ControllerId)
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return;
 	}
-	
+
 	Gamepad->SetLightbar(FColor::Blue);
 }
 
@@ -183,9 +184,9 @@ void DeviceManager::OnUserLoginChangedEvent(bool bLoggedIn, int32 UserId, int32 
 FInputDeviceId DeviceManager::GetGamepadInterface(int32 ControllerId)
 {
 	TArray<FInputDeviceId> Devices;
-	
+
 	IPlatformInputDeviceMapper::Get().GetAllInputDevicesForUser(FPlatformUserId::CreateFromInternalId(ControllerId), Devices);
-	
+
 	for (const FInputDeviceId& DeviceId : Devices)
 	{
 		if (FDeviceRegistry::Get()->GetLibraryInstance(DeviceId))
@@ -195,4 +196,4 @@ FInputDeviceId DeviceManager::GetGamepadInterface(int32 ControllerId)
 	}
 
 	return FInputDeviceId::CreateFromInternalId(INDEX_NONE);
-} 
+}

--- a/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/DualSenseProxy.cpp
@@ -3,14 +3,12 @@
 // Planned Release Year: 2025
 
 #include "DualSenseProxy.h"
-
 #include "AudioDevice.h"
 #include "Core/DeviceRegistry.h"
 #include "Core/DualSense/DualSenseLibrary.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
 #include "Helpers/ValidateHelpers.h"
-
 
 void UDualSenseProxy::DeviceSettings(int32 ControllerId, FDualSenseFeatureReport Settings)
 {
@@ -72,14 +70,21 @@ void UDualSenseProxy::LedPlayerEffects(int32 ControllerId, ELedPlayerEnum Value,
 	Gamepad->SetPlayerLed(Value, Brightness);
 }
 
-
-
 void UDualSenseProxy::SetFeedback(int32 ControllerId, int32 BeginStrength,
                                   int32 MiddleStrength, int32 EndStrength, EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength)) BeginStrength = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(MiddleStrength)) MiddleStrength = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(EndStrength)) EndStrength = 8;
+	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength))
+	{
+		BeginStrength = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(MiddleStrength))
+	{
+		MiddleStrength = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndStrength))
+	{
+		EndStrength = 8;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -98,9 +103,18 @@ void UDualSenseProxy::SetFeedback(int32 ControllerId, int32 BeginStrength,
 
 void UDualSenseProxy::Resistance(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 Strength, EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(StartPosition)) StartPosition = 0;
-	if (!FValidateHelpers::ValidateMaxPosition(EndPosition)) EndPosition = 0;
-	if (!FValidateHelpers::ValidateMaxPosition(Strength)) Strength = 0;
+	if (!FValidateHelpers::ValidateMaxPosition(StartPosition))
+	{
+		StartPosition = 0;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndPosition))
+	{
+		EndPosition = 0;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(Strength))
+	{
+		Strength = 0;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -119,9 +133,18 @@ void UDualSenseProxy::Resistance(int32 ControllerId, int32 StartPosition, int32 
 
 void UDualSenseProxy::AutomaticGun(int32 ControllerId, int32 BeginStrength, int32 MiddleStrength, int32 EndStrength, EControllerHand Hand, bool KeepEffect, float Frequency)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength)) BeginStrength = 6;
-	if (!FValidateHelpers::ValidateMaxPosition(MiddleStrength)) MiddleStrength = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(EndStrength)) EndStrength = 8;
+	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength))
+	{
+		BeginStrength = 6;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(MiddleStrength))
+	{
+		MiddleStrength = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndStrength))
+	{
+		EndStrength = 8;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -177,8 +200,14 @@ void UDualSenseProxy::CustomTrigger(int32 ControllerId, EControllerHand Hand, co
 
 void UDualSenseProxy::ContinuousResistance(int32 ControllerId, int32 StartPosition, int32 Strength, EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(StartPosition)) StartPosition = 0;
-	if (!FValidateHelpers::ValidateMaxPosition(Strength)) Strength = 8;
+	if (!FValidateHelpers::ValidateMaxPosition(StartPosition))
+	{
+		StartPosition = 0;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(Strength))
+	{
+		Strength = 8;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -196,13 +225,25 @@ void UDualSenseProxy::ContinuousResistance(int32 ControllerId, int32 StartPositi
 }
 
 void UDualSenseProxy::Galloping(
-	int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 FirstFoot,
-                                int32 SecondFoot, float Frequency, EControllerHand Hand)
+    int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 FirstFoot,
+    int32 SecondFoot, float Frequency, EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(StartPosition, 8, 1)) StartPosition = 1;
-	if (!FValidateHelpers::ValidateMaxPosition(EndPosition, 9, StartPosition+1)) EndPosition = 9;
-	if (!FValidateHelpers::ValidateMaxPosition(FirstFoot, 8)) FirstFoot = 1;
-	if (!FValidateHelpers::ValidateMaxPosition(SecondFoot, 9, FirstFoot+1)) SecondFoot = 9;
+	if (!FValidateHelpers::ValidateMaxPosition(StartPosition, 8, 1))
+	{
+		StartPosition = 1;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndPosition, 9, StartPosition + 1))
+	{
+		EndPosition = 9;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(FirstFoot, 8))
+	{
+		FirstFoot = 1;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(SecondFoot, 9, FirstFoot + 1))
+	{
+		SecondFoot = 9;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -225,11 +266,20 @@ void UDualSenseProxy::Machine(int32 ControllerId, int32 StartPosition, int32 End
 }
 
 void UDualSenseProxy::Weapon(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 Strength,
-	EControllerHand Hand)
+                             EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(StartPosition)) StartPosition = 0;
-	if (!FValidateHelpers::ValidateMaxPosition(EndPosition)) EndPosition = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(Strength)) Strength = 8;
+	if (!FValidateHelpers::ValidateMaxPosition(StartPosition))
+	{
+		StartPosition = 0;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndPosition))
+	{
+		EndPosition = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(Strength))
+	{
+		Strength = 8;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -249,10 +299,22 @@ void UDualSenseProxy::Weapon(int32 ControllerId, int32 StartPosition, int32 EndP
 void UDualSenseProxy::Bow(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 BeginStrength, int32 EndStrength,
                           EControllerHand Hand)
 {
-	if (!FValidateHelpers::ValidateMaxPosition(StartPosition)) StartPosition = 2;
-	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength)) BeginStrength = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(EndPosition)) EndPosition = 8;
-	if (!FValidateHelpers::ValidateMaxPosition(EndStrength)) EndStrength = 8;
+	if (!FValidateHelpers::ValidateMaxPosition(StartPosition))
+	{
+		StartPosition = 2;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(BeginStrength))
+	{
+		BeginStrength = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndPosition))
+	{
+		EndPosition = 8;
+	}
+	if (!FValidateHelpers::ValidateMaxPosition(EndStrength))
+	{
+		EndStrength = 8;
+	}
 
 	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
 	if (!DeviceId.IsValid())
@@ -266,43 +328,58 @@ void UDualSenseProxy::Bow(int32 ControllerId, int32 StartPosition, int32 EndPosi
 		return;
 	}
 
-    Gamepad->SetBow(StartPosition, EndPosition, BeginStrength, EndStrength, Hand);
+	Gamepad->SetBow(StartPosition, EndPosition, BeginStrength, EndStrength, Hand);
 }
 
 static uint8 MapStartZoneEnum(ETriggerPosition Pos)
 {
-    // Map to provided constants: Start = 0x82, Middle = 0x84, End = 0x80, MidLow = 0x88
-    switch (Pos)
-    {
-    case ETriggerPosition::Start: return 0x82;
-    case ETriggerPosition::Middle: return 0x84;
-    case ETriggerPosition::End: return 0x80;
-    case ETriggerPosition::BeforeEnd: return 0x88; // using MidLow mapping
-    case ETriggerPosition::Off: default: return 0x00;
-    }
+	// Map to provided constants: Start = 0x82, Middle = 0x84, End = 0x80, MidLow = 0x88
+	switch (Pos)
+	{
+		case ETriggerPosition::Start: return 0x82;
+		case ETriggerPosition::Middle: return 0x84;
+		case ETriggerPosition::End: return 0x80;
+		case ETriggerPosition::BeforeEnd: return 0x88; // using MidLow mapping
+		case ETriggerPosition::Off:
+		default: return 0x00;
+	}
 }
 
 static uint8 MapBehavior(ETriggerEffectBehavior Behavior)
 {
-    // EndAtPos = 1, KeepEffect = 2
-    switch (Behavior)
-    {
-    case ETriggerEffectBehavior::Localized: return 0x01; // EndAtPos
-    case ETriggerEffectBehavior::Sustained: return 0x02; // KeepEffect
-    default: return 0x01;
-    }
+	// EndAtPos = 1, KeepEffect = 2
+	switch (Behavior)
+	{
+		case ETriggerEffectBehavior::Localized: return 0x01; // EndAtPos
+		case ETriggerEffectBehavior::Sustained: return 0x02; // KeepEffect
+		default: return 0x01;
+	}
 }
 
 static uint8 ComposeForceAmplitude(ETriggerForceIntensity Force, EDualSenseTriggerAmplitude Amplitude)
 {
-    // High nibble 1-3 from Force, Low nibble 0x0A-0x0F from Amplitude
-    const uint8 forceNib = static_cast<uint8>(Force) & 0x0F;
-    const uint8 ampNib = static_cast<uint8>(Amplitude) & 0x0F;
-    uint8 hi = forceNib;
-    if (hi < 1) hi = 1; if (hi > 3) hi = 3;
-    uint8 lo = ampNib;
-    if (lo < 0x0A) lo = 0x0A; if (lo > 0x0F) lo = 0x0F;
-    return static_cast<uint8>((hi << 4) | (lo & 0x0F));
+	// High nibble 1-3 from Force, Low nibble 0x0A-0x0F from Amplitude
+	const uint8 forceNib = static_cast<uint8>(Force) & 0x0F;
+	const uint8 ampNib = static_cast<uint8>(Amplitude) & 0x0F;
+	uint8 hi = forceNib;
+	if (hi < 1)
+	{
+		hi = 1;
+	}
+	if (hi > 3)
+	{
+		hi = 3;
+	}
+	uint8 lo = ampNib;
+	if (lo < 0x0A)
+	{
+		lo = 0x0A;
+	}
+	if (lo > 0x0F)
+	{
+		lo = 0x0F;
+	}
+	return static_cast<uint8>((hi << 4) | (lo & 0x0F));
 }
 
 void UDualSenseProxy::MachineAdvanced(int32 ControllerId, ETriggerPosition StartZone,
@@ -311,27 +388,27 @@ void UDualSenseProxy::MachineAdvanced(int32 ControllerId, ETriggerPosition Start
                                       EDualSenseTriggerAmplitude Amplitude,
                                       int32 Period, int32 Frequency, EControllerHand Hand)
 {
-    // Clamp ranges
-    Period = FMath::Clamp(Period, 0, 20);
-    Frequency = FMath::Clamp(Frequency, 0, 40);
+	// Clamp ranges
+	Period = FMath::Clamp(Period, 0, 20);
+	Frequency = FMath::Clamp(Frequency, 0, 40);
 
-    const uint8 startZoneByte = MapStartZoneEnum(StartZone);
-    const uint8 behaviorByte = MapBehavior(Behavior);
-    const uint8 forceAmp = ComposeForceAmplitude(ForceIntensity, Amplitude);
+	const uint8 startZoneByte = MapStartZoneEnum(StartZone);
+	const uint8 behaviorByte = MapBehavior(Behavior);
+	const uint8 forceAmp = ComposeForceAmplitude(ForceIntensity, Amplitude);
 
-    const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
-    if (!DeviceId.IsValid())
-    {
-        return;
-    }
+	const FInputDeviceId DeviceId = GetGamepadInterface(ControllerId);
+	if (!DeviceId.IsValid())
+	{
+		return;
+	}
 
-    ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
-    if (!Gamepad)
-    {
-        return;
-    }
+	ISonyGamepadTriggerInterface* Gamepad = Cast<ISonyGamepadTriggerInterface>(FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
+	if (!Gamepad)
+	{
+		return;
+	}
 
-    Gamepad->SetMachine27(startZoneByte, behaviorByte, forceAmp, static_cast<uint8>(Period), static_cast<uint8>(Frequency), Hand);
+	Gamepad->SetMachine27(startZoneByte, behaviorByte, forceAmp, static_cast<uint8>(Period), static_cast<uint8>(Frequency), Hand);
 }
 
 void UDualSenseProxy::NoResistance(int32 ControllerId, EControllerHand Hand)

--- a/Source/WindowsDualsense_ds5w/Private/Helpers/CommandHelpers.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Helpers/CommandHelpers.cpp
@@ -1,67 +1,58 @@
 ﻿#include "Helpers/CommandHelpers.h"
-#include "HAL/IConsoleManager.h"
 #include "Core/DeviceRegistry.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
-#include "Core/Structs/DeviceContext.h"
 #include "Core/PlayStationOutputComposer.h"
+#include "Core/Structs/DeviceContext.h"
+#include "HAL/IConsoleManager.h"
 
 static FAutoConsoleCommand GCmd_SetAudioByte(
-	TEXT("ds.SetAudioByte"),
-	TEXT("ds.SetAudioByte <DeviceId> <Index 0-9> <Value 0-255>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetAudioByte)
-);
+    TEXT("ds.SetAudioByte"),
+    TEXT("ds.SetAudioByte <DeviceId> <Index 0-9> <Value 0-255>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetAudioByte));
 static FAutoConsoleCommand GCmd_SetAudioLR(
-	TEXT("ds.SetAudioLR"),
-	TEXT("ds.SetAudioLR <DeviceId> <L1> <L2> <R1> <R2> <Master> (0-255)"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetAudioLR)
-);
+    TEXT("ds.SetAudioLR"),
+    TEXT("ds.SetAudioLR <DeviceId> <L1> <L2> <R1> <R2> <Master> (0-255)"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetAudioLR));
 static FAutoConsoleCommand GCmd_DumpAudioBytes(
-	TEXT("ds.DumpAudioBytes"),
-	TEXT("ds.DumpAudioBytes <DeviceId>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleDumpAudioBytes)
-);
+    TEXT("ds.DumpAudioBytes"),
+    TEXT("ds.DumpAudioBytes <DeviceId>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleDumpAudioBytes));
 static FAutoConsoleCommand GCmd_SetTrigR(
-	TEXT("ds.SetTrigR"),
-	TEXT("ds.SetTrigR <DeviceId> <hex bytes up to 10> e.g. 22 3F 08 01"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetTrigR)
-);
+    TEXT("ds.SetTrigR"),
+    TEXT("ds.SetTrigR <DeviceId> <hex bytes up to 10> e.g. 22 3F 08 01"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetTrigR));
 static FAutoConsoleCommand GCmd_SetTrigL(
-	TEXT("ds.SetTrigL"),
-	TEXT("ds.SetTrigL <DeviceId> <hex bytes up to 10> e.g. 22 3F 08 01"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetTrigL)
-);
+    TEXT("ds.SetTrigL"),
+    TEXT("ds.SetTrigL <DeviceId> <hex bytes up to 10> e.g. 22 3F 08 01"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleSetTrigL));
 static FAutoConsoleCommand GCmd_DumpTrig(
-	TEXT("ds.DumpTrig"),
-	TEXT("ds.DumpTrig <DeviceId>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleDumpTrig)
-);
+    TEXT("ds.DumpTrig"),
+    TEXT("ds.DumpTrig <DeviceId>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleDumpTrig));
 static FAutoConsoleCommand GCmd_ClearTrig(
-	TEXT("ds.ClearTrig"),
-	TEXT("ds.ClearTrig <DeviceId>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleClearTrig)
-);
+    TEXT("ds.ClearTrig"),
+    TEXT("ds.ClearTrig <DeviceId>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleClearTrig));
 static FAutoConsoleCommand GCmd_BowR(
-	TEXT("ds.BowR"),
-	TEXT("ds.BowR <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleBowTrigR)
-);
+    TEXT("ds.BowR"),
+    TEXT("ds.BowR <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleBowTrigR));
 static FAutoConsoleCommand GCmd_BowL(
-	TEXT("ds.BowL"),
-	TEXT("ds.BowL <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleBowTrigL)
-);
+    TEXT("ds.BowL"),
+    TEXT("ds.BowL <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleBowTrigL));
 static FAutoConsoleCommand GCmd_GallopR(
-	TEXT("ds.GallopR"),
-	TEXT("ds.GallopR <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleGallopTrigR)
-);
+    TEXT("ds.GallopR"),
+    TEXT("ds.GallopR <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleGallopTrigR));
 static FAutoConsoleCommand GCmd_GallopL(
-	TEXT("ds.GallopL"),
-	TEXT("ds.GallopL <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleGallopTrigL)
-);
+    TEXT("ds.GallopL"),
+    TEXT("ds.GallopL <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&FCommandHelpers::HandleGallopTrigL));
 
-void FCommandHelpers::Register() { /* static commands auto-register */ }
+void FCommandHelpers::Register()
+{ /* static commands auto-register */
+}
 
 bool FCommandHelpers::ParseDeviceId(const TArray<FString>& Args, FInputDeviceId& OutDeviceId)
 {
@@ -92,13 +83,18 @@ bool FCommandHelpers::ParseHexByte(const FString& Token, uint8& OutByte)
 	{
 		S.RightChopInline(2);
 	}
-	if (S.IsEmpty()) { OutByte = 0; return false; }
+	if (S.IsEmpty())
+	{
+		OutByte = 0;
+		return false;
+	}
 	for (int32 i = 0; i < S.Len(); ++i)
 	{
 		TCHAR C = S[i];
 		if (!((C >= '0' && C <= '9') || (C >= 'a' && C <= 'f') || (C >= 'A' && C <= 'F')))
 		{
-			OutByte = 0; return false;
+			OutByte = 0;
+			return false;
 		}
 	}
 	int32 Value = 0;
@@ -106,9 +102,18 @@ bool FCommandHelpers::ParseHexByte(const FString& Token, uint8& OutByte)
 	{
 		TCHAR C = S[i];
 		int32 Nibble = 0;
-		if (C >= '0' && C <= '9') Nibble = C - '0';
-		else if (C >= 'a' && C <= 'f') Nibble = 10 + (C - 'a');
-		else if (C >= 'A' && C <= 'F') Nibble = 10 + (C - 'A');
+		if (C >= '0' && C <= '9')
+		{
+			Nibble = C - '0';
+		}
+		else if (C >= 'a' && C <= 'f')
+		{
+			Nibble = 10 + (C - 'a');
+		}
+		else if (C >= 'A' && C <= 'F')
+		{
+			Nibble = 10 + (C - 'A');
+		}
 		Value = (Value << 4) | Nibble;
 	}
 	OutByte = ClampByte(Value);
@@ -117,13 +122,34 @@ bool FCommandHelpers::ParseHexByte(const FString& Token, uint8& OutByte)
 
 void FCommandHelpers::HandleSetAudioByte(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	if (Args.Num() < 3) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.SetAudioByte <DeviceId> <Index 0-9> <Value 0-255>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 3)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.SetAudioByte <DeviceId> <Index 0-9> <Value 0-255>"));
+		return;
+	}
 	int32 Index = FCString::Atoi(*Args[1]);
 	int32 Value = FCString::Atoi(*Args[2]);
-	if (Index < 0 || Index > 9) { UE_LOG(LogTemp, Warning, TEXT("Index out of range (0-9)")); return; }
+	if (Index < 0 || Index > 9)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Index out of range (0-9)"));
+		return;
+	}
 	Ctx->BufferAudio[Index] = ClampByte(Value);
 	UE_LOG(LogTemp, Log, TEXT("Audio byte[%d] = %d"), Index, (int32)Ctx->BufferAudio[Index]);
 	FPlayStationOutputComposer::OutputDualSense(Ctx);
@@ -131,15 +157,32 @@ void FCommandHelpers::HandleSetAudioByte(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleSetAudioLR(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	if (Args.Num() < 6) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.SetAudioLR <DeviceId> <L1> <L2> <R1> <R2> <Master>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 6)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.SetAudioLR <DeviceId> <L1> <L2> <R1> <R2> <Master>"));
+		return;
+	}
 	int32 L1 = FCString::Atoi(*Args[1]);
 	int32 L2 = FCString::Atoi(*Args[2]);
 	int32 R1 = FCString::Atoi(*Args[3]);
 	int32 R2 = FCString::Atoi(*Args[4]);
-	int32 X  = FCString::Atoi(*Args[5]);
+	int32 X = FCString::Atoi(*Args[5]);
 	Ctx->BufferAudio[5] = ClampByte(L1);
 	Ctx->BufferAudio[6] = ClampByte(L2);
 	Ctx->BufferAudio[7] = ClampByte(R1);
@@ -151,9 +194,22 @@ void FCommandHelpers::HandleSetAudioLR(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleDumpAudioBytes(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
 	for (int32 i = 0; i < 10; ++i)
 	{
 		UE_LOG(LogTemp, Log, TEXT("Audio byte[%d] = %d"), i, (int32)Ctx->BufferAudio[i]);
@@ -162,13 +218,31 @@ void FCommandHelpers::HandleDumpAudioBytes(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleSetTrigR(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
 	FMemory::Memset(Ctx->OverrideTriggerRight, 0, 10);
 	for (int32 i = 0; i < 10 && (i + 1) < Args.Num(); ++i)
 	{
-		uint8 B = 0; if (!ParseHexByte(Args[i + 1], B)) { UE_LOG(LogTemp, Warning, TEXT("Invalid hex at pos %d"), i); return; }
+		uint8 B = 0;
+		if (!ParseHexByte(Args[i + 1], B))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Invalid hex at pos %d"), i);
+			return;
+		}
 		Ctx->OverrideTriggerRight[i] = B;
 	}
 	Ctx->bOverrideTriggerBytes = true;
@@ -178,13 +252,31 @@ void FCommandHelpers::HandleSetTrigR(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleSetTrigL(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
 	FMemory::Memset(Ctx->OverrideTriggerLeft, 0, 10);
 	for (int32 i = 0; i < 10 && (i + 1) < Args.Num(); ++i)
 	{
-		uint8 B = 0; if (!ParseHexByte(Args[i + 1], B)) { UE_LOG(LogTemp, Warning, TEXT("Invalid hex at pos %d"), i); return; }
+		uint8 B = 0;
+		if (!ParseHexByte(Args[i + 1], B))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Invalid hex at pos %d"), i);
+			return;
+		}
 		Ctx->OverrideTriggerLeft[i] = B;
 	}
 	Ctx->bOverrideTriggerBytes = true;
@@ -194,10 +286,24 @@ void FCommandHelpers::HandleSetTrigL(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleDumpTrig(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	char R[10] = {0}; char L[10] = {0};
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	char R[10] = {0};
+	char L[10] = {0};
 	FMemory::Memcpy(R, Ctx->OverrideTriggerRight, 10);
 	FMemory::Memcpy(L, Ctx->OverrideTriggerLeft, 10);
 	UE_LOG(LogTemp, Log, TEXT("Dumping OVERRIDE trigger bytes (HEX):"));
@@ -213,28 +319,55 @@ void FCommandHelpers::HandleDumpTrig(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleClearTrig(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx) return;
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx)
+	{
+		return;
+	}
 	Ctx->bOverrideTriggerBytes = false;
 	FMemory::Memset(Ctx->OverrideTriggerRight, 0, 10);
 	FMemory::Memset(Ctx->OverrideTriggerLeft, 0, 10);
 	UE_LOG(LogTemp, Log, TEXT("Trigger overrides cleared."));
-	if (Ctx->IsConnected) { FPlayStationOutputComposer::OutputDualSense(Ctx); }
+	if (Ctx->IsConnected)
+	{
+		FPlayStationOutputComposer::OutputDualSense(Ctx);
+	}
 }
 
 static bool ComposeBowBytes(uint8 Out[10], int32 StartPosition, int32 EndPosition, int32 ResistancePos, int32 ForcePos)
 {
 	// Validate ranges
-	if (StartPosition < 0 || StartPosition > 7) return false;
-	if (EndPosition < 0 || EndPosition > 8) return false;
+	if (StartPosition < 0 || StartPosition > 7)
+	{
+		return false;
+	}
+	if (EndPosition < 0 || EndPosition > 8)
+	{
+		return false;
+	}
 	// New spec: Resistance/Force provided in 0..8 positions, convert to 0..255 scale, then to nibble 0..15
-	if (ResistancePos < 0 || ResistancePos > 9) return false;
-	if (ForcePos < 0 || ForcePos > 8) return false;
-	
+	if (ResistancePos < 0 || ResistancePos > 9)
+	{
+		return false;
+	}
+	if (ForcePos < 0 || ForcePos > 8)
+	{
+		return false;
+	}
+
 	// Quantize 0..255 -> nibble 0..15 used by protocol
 	const uint8 ResistanceNib = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((ResistancePos / 9.0f) * 15.0f), 0, 15));
-	const uint8 SnapNib      = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((ForcePos / 8.0f) * 15.0f), 0, 15));
+	const uint8 SnapNib = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((ForcePos / 8.0f) * 15.0f), 0, 15));
 	FMemory::Memset(Out, 0, 10);
 	Out[0] = 0x22;
 	Out[1] = static_cast<uint8>((1 << StartPosition) | 0x02);
@@ -246,23 +379,50 @@ static bool ComposeBowBytes(uint8 Out[10], int32 StartPosition, int32 EndPositio
 static bool ComposeGallopBytes(uint8 Out[10], int32 StartPosition, int32 EndPosition, int32 FirstFoot, int32 SecondFoot, int32 Frequency)
 {
 	// Validate positions following DualSenseLibrary::SetGalloping expectations
-	if (StartPosition < 0 || StartPosition > 8) return false;
-	if (EndPosition < 1 || EndPosition > 9) return false;
-	if (EndPosition <= StartPosition) return false;
-	if (FirstFoot < 0 || FirstFoot > 8) return false;
-	if (SecondFoot < 1 || SecondFoot > 9) return false;
-	if (SecondFoot <= FirstFoot) return false;
-	if (Frequency < 0 || Frequency > 255) return false;
+	if (StartPosition < 0 || StartPosition > 8)
+	{
+		return false;
+	}
+	if (EndPosition < 1 || EndPosition > 9)
+	{
+		return false;
+	}
+	if (EndPosition <= StartPosition)
+	{
+		return false;
+	}
+	if (FirstFoot < 0 || FirstFoot > 8)
+	{
+		return false;
+	}
+	if (SecondFoot < 1 || SecondFoot > 9)
+	{
+		return false;
+	}
+	if (SecondFoot <= FirstFoot)
+	{
+		return false;
+	}
+	if (Frequency < 0 || Frequency > 255)
+	{
+		return false;
+	}
 
 	const uint8 FirstFootNib = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((FirstFoot / 8.0f) * 15.0f), 1, 15));
 	const uint8 SecondFootNib = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((SecondFoot / 8.0f) * 15.0f), 1, 15));
 
 	int32 KeepEffect = 0; // 0 none, 1 keep at 8, 2 keep at 9
-	if (EndPosition >= 8) { KeepEffect = 1; }
-	if (EndPosition >= 9) { KeepEffect = 2; }
+	if (EndPosition >= 8)
+	{
+		KeepEffect = 1;
+	}
+	if (EndPosition >= 9)
+	{
+		KeepEffect = 2;
+	}
 
 	FMemory::Memset(Out, 0, 10);
-	Out[0] = 0x23; // Galloping mode
+	Out[0] = 0x23;                                                          // Galloping mode
 	Out[1] = static_cast<uint8>((1 << StartPosition) | (1 << EndPosition)); // active zones bitmask
 	Out[2] = static_cast<uint8>(KeepEffect);
 	Out[3] = static_cast<uint8>(((FirstFootNib & 0x0F) << 4) | (SecondFootNib & 0x0F));
@@ -272,16 +432,37 @@ static bool ComposeGallopBytes(uint8 Out[10], int32 StartPosition, int32 EndPosi
 
 void FCommandHelpers::HandleBowTrigR(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
- if (Args.Num() < 5) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.BowR <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 5)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.BowR <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"));
+		return;
+	}
 	int32 Start = FCString::Atoi(*Args[1]);
 	int32 End = FCString::Atoi(*Args[2]);
 	int32 Resistance = FCString::Atoi(*Args[3]);
 	int32 Force = FCString::Atoi(*Args[4]);
 	uint8 Bytes[10] = {0};
-	if (!ComposeBowBytes(Bytes, Start, End, Resistance, Force)) { UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range.")); return; }
+	if (!ComposeBowBytes(Bytes, Start, End, Resistance, Force))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range."));
+		return;
+	}
 	FMemory::Memcpy(Ctx->OverrideTriggerRight, Bytes, 10);
 	Ctx->bOverrideTriggerBytes = true;
 	UE_LOG(LogTemp, Log, TEXT("Right trigger set to Bow effect: [%02X %02X %02X %02X]"), Bytes[0], Bytes[1], Bytes[2], Bytes[3]);
@@ -290,16 +471,37 @@ void FCommandHelpers::HandleBowTrigR(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleBowTrigL(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	if (Args.Num() < 5) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.BowL <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 5)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.BowL <DeviceId> <Start 0-7> <End 0-8> <ResistancePos 0-8> <ForcePos 0-8>"));
+		return;
+	}
 	int32 Start = FCString::Atoi(*Args[1]);
 	int32 End = FCString::Atoi(*Args[2]);
 	int32 Resistance = FCString::Atoi(*Args[3]);
 	int32 Force = FCString::Atoi(*Args[4]);
 	uint8 Bytes[10] = {0};
-	if (!ComposeBowBytes(Bytes, Start, End, Resistance, Force)) { UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range.")); return; }
+	if (!ComposeBowBytes(Bytes, Start, End, Resistance, Force))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range."));
+		return;
+	}
 	FMemory::Memcpy(Ctx->OverrideTriggerLeft, Bytes, 10);
 	Ctx->bOverrideTriggerBytes = true;
 	UE_LOG(LogTemp, Log, TEXT("Left trigger set to Bow effect: [%02X %02X %02X %02X]"), Bytes[0], Bytes[1], Bytes[2], Bytes[3]);
@@ -308,17 +510,38 @@ void FCommandHelpers::HandleBowTrigL(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleGallopTrigR(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	if (Args.Num() < 6) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.GallopR <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 6)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.GallopR <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"));
+		return;
+	}
 	int32 Start = FCString::Atoi(*Args[1]);
 	int32 End = FCString::Atoi(*Args[2]);
 	int32 FirstFoot = FCString::Atoi(*Args[3]);
 	int32 SecondFoot = FCString::Atoi(*Args[4]);
 	int32 Freq = FCString::Atoi(*Args[5]);
 	uint8 Bytes[10] = {0};
-	if (!ComposeGallopBytes(Bytes, Start, End, FirstFoot, SecondFoot, Freq)) { UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range.")); return; }
+	if (!ComposeGallopBytes(Bytes, Start, End, FirstFoot, SecondFoot, Freq))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range."));
+		return;
+	}
 	FMemory::Memcpy(Ctx->OverrideTriggerRight, Bytes, 10);
 	Ctx->bOverrideTriggerBytes = true;
 	UE_LOG(LogTemp, Log, TEXT("Right trigger set to Gallop effect: [%02X %02X %02X %02X %02X]"), Bytes[0], Bytes[1], Bytes[2], Bytes[3], Bytes[4]);
@@ -327,17 +550,38 @@ void FCommandHelpers::HandleGallopTrigR(const TArray<FString>& Args)
 
 void FCommandHelpers::HandleGallopTrigL(const TArray<FString>& Args)
 {
-	FInputDeviceId DeviceId; if (!ParseDeviceId(Args, DeviceId)) return;
-	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId); if (!Gamepad) return;
-	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext(); if (!Ctx || !Ctx->IsConnected) { UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected")); return; }
-	if (Args.Num() < 6) { UE_LOG(LogTemp, Warning, TEXT("Usage: ds.GallopL <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>")); return; }
+	FInputDeviceId DeviceId;
+	if (!ParseDeviceId(Args, DeviceId))
+	{
+		return;
+	}
+	ISonyGamepadInterface* Gamepad = GetGamepad(DeviceId);
+	if (!Gamepad)
+	{
+		return;
+	}
+	FDeviceContext* Ctx = Gamepad->GetMutableDeviceContext();
+	if (!Ctx || !Ctx->IsConnected)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Device not ready/connected"));
+		return;
+	}
+	if (Args.Num() < 6)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Usage: ds.GallopL <DeviceId> <Start 0-8> <End 1-9> <FirstFoot 0-8> <SecondFoot 1-9> <Freq 0-255>"));
+		return;
+	}
 	int32 Start = FCString::Atoi(*Args[1]);
 	int32 End = FCString::Atoi(*Args[2]);
 	int32 FirstFoot = FCString::Atoi(*Args[3]);
 	int32 SecondFoot = FCString::Atoi(*Args[4]);
 	int32 Freq = FCString::Atoi(*Args[5]);
 	uint8 Bytes[10] = {0};
-	if (!ComposeGallopBytes(Bytes, Start, End, FirstFoot, SecondFoot, Freq)) { UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range.")); return; }
+	if (!ComposeGallopBytes(Bytes, Start, End, FirstFoot, SecondFoot, Freq))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Invalid parameter range."));
+		return;
+	}
 	FMemory::Memcpy(Ctx->OverrideTriggerLeft, Bytes, 10);
 	Ctx->bOverrideTriggerBytes = true;
 	UE_LOG(LogTemp, Log, TEXT("Left trigger set to Gallop effect: [%02X %02X %02X %02X %02X]"), Bytes[0], Bytes[1], Bytes[2], Bytes[3], Bytes[4]);

--- a/Source/WindowsDualsense_ds5w/Private/Helpers/ValidateHelpers.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Helpers/ValidateHelpers.cpp
@@ -21,8 +21,14 @@ bool FValidateHelpers::ValidateMaxFrequency(const float Frequency)
 
 int FValidateHelpers::To255(const float Value)
 {
-	if (Value <= 0) return 0;
-	if (Value >= 1.0f) return 255;
+	if (Value <= 0)
+	{
+		return 0;
+	}
+	if (Value >= 1.0f)
+	{
+		return 255;
+	}
 
 	constexpr float Min = 0;
 	constexpr float Max = 1.0;
@@ -32,8 +38,14 @@ int FValidateHelpers::To255(const float Value)
 
 int FValidateHelpers::To255(const unsigned char Value, const unsigned char MaxInput)
 {
-	if (Value <= 0) return 0;
-	if (Value >= MaxInput) return 255;
+	if (Value <= 0)
+	{
+		return 0;
+	}
+	if (Value >= MaxInput)
+	{
+		return 255;
+	}
 
 	return ((Value * 255.0f) / MaxInput);
 }

--- a/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/SonyGamepadProxy.cpp
@@ -2,12 +2,11 @@
 // Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
 // Planned Release Year: 2025
 
-
 #include "SonyGamepadProxy.h"
-#include "Misc/CoreDelegates.h"
 #include "Core/DeviceRegistry.h"
 #include "Core/DualSense/DualSenseLibrary.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
+#include "Misc/CoreDelegates.h"
 
 EDeviceType USonyGamepadProxy::GetDeviceType(int32 ControllerId)
 {
@@ -16,7 +15,7 @@ EDeviceType USonyGamepadProxy::GetDeviceType(int32 ControllerId)
 	{
 		return EDeviceType::NotFound;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -33,7 +32,7 @@ EDeviceConnection USonyGamepadProxy::GetConnectionType(int32 ControllerId)
 	{
 		return EDeviceConnection::Unrecognized;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -50,13 +49,13 @@ bool USonyGamepadProxy::DeviceIsConnected(int32 ControllerId)
 	{
 		return false;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return false;
 	}
-	
+
 	return true;
 }
 
@@ -67,13 +66,13 @@ float USonyGamepadProxy::LevelBatteryDevice(int32 ControllerId)
 	{
 		return 0.0f;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
 		return 0.0f;
 	}
-	
+
 	return Gamepad->GetBattery();
 }
 
@@ -84,7 +83,7 @@ void USonyGamepadProxy::LedColorEffects(int32 ControllerId, FColor Color, float 
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -101,7 +100,7 @@ void USonyGamepadProxy::LedMicEffects(int32 ControllerId, ELedMicEnum Value)
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -118,7 +117,7 @@ void USonyGamepadProxy::StartMotionSensorCalibration(int32 ControllerId, float D
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -150,7 +149,7 @@ bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, flo
 	{
 		return false;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -158,11 +157,11 @@ bool USonyGamepadProxy::GetMotionSensorCalibrationStatus(int32 ControllerId, flo
 		return false;
 	}
 
-	if (UDualSenseLibrary* DsLibrary  = Cast<UDualSenseLibrary>(Gamepad))
+	if (UDualSenseLibrary* DsLibrary = Cast<UDualSenseLibrary>(Gamepad))
 	{
 		return DsLibrary->GetMotionSensorCalibrationStatus(Progress);
 	}
-	
+
 	return false;
 }
 
@@ -173,7 +172,7 @@ void USonyGamepadProxy::EnableTouch(int32 ControllerId, bool bEnableTouch)
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -190,7 +189,7 @@ void USonyGamepadProxy::EnableGyroscopeValues(int32 ControllerId, bool bEnableGy
 	{
 		return;
 	}
-	
+
 	ISonyGamepadInterface* Gamepad = FDeviceRegistry::Get()->GetLibraryInstance(DeviceId);
 	if (!Gamepad)
 	{
@@ -205,9 +204,9 @@ FInputDeviceId USonyGamepadProxy::GetGamepadInterface(int32 ControllerId)
 	check(IsInGameThread());
 
 	TArray<FInputDeviceId> Devices;
-	
+
 	IPlatformInputDeviceMapper::Get().GetAllInputDevicesForUser(FPlatformUserId::CreateFromInternalId(ControllerId), Devices);
-	
+
 	for (const FInputDeviceId& DeviceId : Devices)
 	{
 		if (FDeviceRegistry::Get()->GetLibraryInstance(DeviceId))

--- a/Source/WindowsDualsense_ds5w/Private/Subsystems/AudioHapticsListener.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Subsystems/AudioHapticsListener.cpp
@@ -7,7 +7,9 @@
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
 #include "Core/Structs/DualSenseFeatureReport.h"
 
-FAudioHapticsListener::FAudioHapticsListener(FInputDeviceId InDeviceId, USoundSubmix* InSubmix) : Submix(InSubmix), DeviceId(InDeviceId)
+FAudioHapticsListener::FAudioHapticsListener(FInputDeviceId InDeviceId, USoundSubmix* InSubmix)
+    : Submix(InSubmix)
+    , DeviceId(InDeviceId)
 {
 	ResampledAudioBuffer.SetNumUninitialized(64);
 }
@@ -15,116 +17,114 @@ FAudioHapticsListener::FAudioHapticsListener(FInputDeviceId InDeviceId, USoundSu
 void FAudioHapticsListener::OnNewSubmixBuffer(const USoundSubmix* OwningSubmix, float* AudioData, int32 NumSamples,
                                               int32 NumChannels, const int32 SampleRate, double AudioClock)
 {
-    if (!ResamplerImpl.IsValid())
-    {
-        const float Ratio = 3000.0f / SampleRate;
-        ResamplerImpl = MakeUnique<Audio::FResampler>();
-        ResamplerImpl->Init(
-            Audio::EResamplingMethod::BestSinc,
-            Ratio,
-            NumChannels
-        );
-    }
-    const int32 NumInputFrames = NumSamples / NumChannels; // (2048 samples / 2 channels = 1024 frames)
+	if (!ResamplerImpl.IsValid())
+	{
+		const float Ratio = 3000.0f / SampleRate;
+		ResamplerImpl = MakeUnique<Audio::FResampler>();
+		ResamplerImpl->Init(
+		    Audio::EResamplingMethod::BestSinc,
+		    Ratio,
+		    NumChannels);
+	}
+	const int32 NumInputFrames = NumSamples / NumChannels; // (2048 samples / 2 channels = 1024 frames)
 
-    // (1024 frames * (3000/48000)) = 64 frames.
-    const int32 ExpectedOutputFrames = FMath::CeilToInt(static_cast<float>(NumInputFrames) * (3000.0f / SampleRate));
-    ResampledAudioBuffer.SetNumUninitialized((ExpectedOutputFrames + 32) * NumChannels);
+	// (1024 frames * (3000/48000)) = 64 frames.
+	const int32 ExpectedOutputFrames = FMath::CeilToInt(static_cast<float>(NumInputFrames) * (3000.0f / SampleRate));
+	ResampledAudioBuffer.SetNumUninitialized((ExpectedOutputFrames + 32) * NumChannels);
 
-    int32 OutputFramesWritten = 0;
-    ResamplerImpl->ProcessAudio(
-        AudioData,
-        NumInputFrames,
-        false,
-        ResampledAudioBuffer.GetData(),
-        ResampledAudioBuffer.Num() / NumChannels,
-        OutputFramesWritten
-    );
+	int32 OutputFramesWritten = 0;
+	ResamplerImpl->ProcessAudio(
+	    AudioData,
+	    NumInputFrames,
+	    false,
+	    ResampledAudioBuffer.GetData(),
+	    ResampledAudioBuffer.Num() / NumChannels,
+	    OutputFramesWritten);
 
-    if (OutputFramesWritten != 64)
-    {
-        UE_LOG(LogTemp, Warning, TEXT("OutputFramesWritten not 64 bytes! (%d)"), OutputFramesWritten);
-        return;
-    }
+	if (OutputFramesWritten != 64)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("OutputFramesWritten not 64 bytes! (%d)"), OutputFramesWritten);
+		return;
+	}
 
 	const float alpha = 0.2f;
 	const float one_minus_alpha = 0.5f - alpha;
-	
+
 	float* Data = ResampledAudioBuffer.GetData();
 	const int32 NumFrames = OutputFramesWritten; // Serão 64 frames
 
 	for (int32 i = 0; i < NumFrames; ++i)
 	{
 		const int32 DataIndex = i * NumChannels; // (i * 2)
-  
-		const float InLeft  = Data[DataIndex];
+
+		const float InLeft = Data[DataIndex];
 		const float InRight = Data[DataIndex + 1];
-		
+
 		// y_lp[n] = (1 - alpha) * x[n] + alpha * y_lp[n-1]
-		LowPassState_Left  = one_minus_alpha * InLeft  + alpha * LowPassState_Left;
+		LowPassState_Left = one_minus_alpha * InLeft + alpha * LowPassState_Left;
 		LowPassState_Right = one_minus_alpha * InRight + alpha * LowPassState_Right;
-		
+
 		// y_hp[n] = x[n] - y_lp[n]
-		const float OutLeft  = InLeft  - LowPassState_Left;
+		const float OutLeft = InLeft - LowPassState_Left;
 		const float OutRight = InRight - LowPassState_Right;
-		
-		Data[DataIndex]     = OutLeft;
+
+		Data[DataIndex] = OutLeft;
 		Data[DataIndex + 1] = OutRight;
 	}
 
-    const float* ResampledData = ResampledAudioBuffer.GetData();
-    TArray<int8> Packet1, Packet2;
-    Packet1.SetNumUninitialized(64);
-    Packet2.SetNumUninitialized(64);
+	const float* ResampledData = ResampledAudioBuffer.GetData();
+	TArray<int8> Packet1, Packet2;
+	Packet1.SetNumUninitialized(64);
+	Packet2.SetNumUninitialized(64);
 
-    for (int32 i = 0; i < 32; ++i)
-    {
-        const int32 DataIndex = i * 2;
-        
-        const float LeftSample  = ResampledData[DataIndex]; // L
-        const float RightSample = ResampledData[DataIndex + 1]; // R
+	for (int32 i = 0; i < 32; ++i)
+	{
+		const int32 DataIndex = i * 2;
 
-        const int8 LeftSampleInt8  = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(LeftSample * 127.0f), -128, 127));
-        const int8 RightSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(RightSample * 127.0f), -128, 127));
+		const float LeftSample = ResampledData[DataIndex];      // L
+		const float RightSample = ResampledData[DataIndex + 1]; // R
 
-        Packet1[DataIndex]     = LeftSampleInt8;  // L
-        Packet1[DataIndex + 1] = RightSampleInt8; // R
-    }
-    
-    // (Frames 32-63)
-    for (int32 i = 0; i < 32; ++i)
-    {
-        // Freame 32 (i + 32) * 2
-        const int32 DataIndex = (i + 32) * 2; // ResampledData (64, 66, 68...)
-        
-        const float LeftSample  = ResampledData[DataIndex];
-        const float RightSample = ResampledData[DataIndex + 1];
+		const int8 LeftSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(LeftSample * 127.0f), -128, 127));
+		const int8 RightSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(RightSample * 127.0f), -128, 127));
 
-        const int8 LeftSampleInt8  = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(LeftSample * 127.0f), -128, 127));
-        const int8 RightSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(RightSample * 127.0f), -128, 127));
+		Packet1[DataIndex] = LeftSampleInt8;      // L
+		Packet1[DataIndex + 1] = RightSampleInt8; // R
+	}
 
-        // Index *Packet 2* (Packet2)
-        const int32 PacketIndex = i * 2; // (0, 2, 4...)
-        Packet2[PacketIndex]     = LeftSampleInt8;  // L
-        Packet2[PacketIndex + 1] = RightSampleInt8; // R
-    }
+	// (Frames 32-63)
+	for (int32 i = 0; i < 32; ++i)
+	{
+		// Freame 32 (i + 32) * 2
+		const int32 DataIndex = (i + 32) * 2; // ResampledData (64, 66, 68...)
 
-    AudioPacketQueue.Enqueue(Packet1);
-    AudioPacketQueue.Enqueue(Packet2);
+		const float LeftSample = ResampledData[DataIndex];
+		const float RightSample = ResampledData[DataIndex + 1];
+
+		const int8 LeftSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(LeftSample * 127.0f), -128, 127));
+		const int8 RightSampleInt8 = static_cast<int8>(FMath::Clamp(FMath::RoundToInt(RightSample * 127.0f), -128, 127));
+
+		// Index *Packet 2* (Packet2)
+		const int32 PacketIndex = i * 2;            // (0, 2, 4...)
+		Packet2[PacketIndex] = LeftSampleInt8;      // L
+		Packet2[PacketIndex + 1] = RightSampleInt8; // R
+	}
+
+	AudioPacketQueue.Enqueue(Packet1);
+	AudioPacketQueue.Enqueue(Packet2);
 }
 
 void FAudioHapticsListener::ConsumeHapticsQueue()
 {
-    ISonyGamepadTriggerInterface* DualSenseInterface = Cast<ISonyGamepadTriggerInterface>(
-        FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
-    if (DualSenseInterface)
+	ISonyGamepadTriggerInterface* DualSenseInterface = Cast<ISonyGamepadTriggerInterface>(
+	    FDeviceRegistry::Get()->GetLibraryInstance(DeviceId));
+	if (DualSenseInterface)
 	{
 		TArray<int8> PacketToProcess;
-	    while (AudioPacketQueue.Dequeue(PacketToProcess))
-	    {
-	        DualSenseInterface->AudioHapticUpdate(PacketToProcess);
-	    }
-    	return;
+		while (AudioPacketQueue.Dequeue(PacketToProcess))
+		{
+			DualSenseInterface->AudioHapticUpdate(PacketToProcess);
+		}
+		return;
 	}
 	AudioPacketQueue.Empty();
 }

--- a/Source/WindowsDualsense_ds5w/Private/Subsystems/SonyInputProcessor.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Subsystems/SonyInputProcessor.cpp
@@ -50,13 +50,13 @@ bool FSonyInputProcessor::HandleMouseButtonUpEvent(FSlateApplication& SlateApp, 
 }
 
 bool FSonyInputProcessor::HandleMouseButtonDoubleClickEvent(FSlateApplication& SlateApp,
-	const FPointerEvent& MouseEvent)
+                                                            const FPointerEvent& MouseEvent)
 {
 	return IInputProcessor::HandleMouseButtonDoubleClickEvent(SlateApp, MouseEvent);
 }
 
 bool FSonyInputProcessor::HandleMouseWheelOrGestureEvent(FSlateApplication& SlateApp, const FPointerEvent& InWheelEvent,
-	const FPointerEvent* InGestureEvent)
+                                                         const FPointerEvent* InGestureEvent)
 {
 	return IInputProcessor::HandleMouseWheelOrGestureEvent(SlateApp, InWheelEvent, InGestureEvent);
 }

--- a/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
@@ -2,17 +2,16 @@
 // Created for: WindowsDualsense_ds5w - Plugin to support DualSense controller on Windows.
 // Planned Release Year: 2025
 
-
 #include "WindowsDualsense_ds5w/Public/WindowsDualsense_ds5w.h"
 
 #if PLATFORM_LINUX || PLATFORM_MAC
+#include "Framework/Application/SlateApplication.h"
 #include "SDL.h"
 #include "Subsystems/SonyInputProcessor.h"
-#include "Framework/Application/SlateApplication.h"
 #endif
+#include "DeviceManager.h"
 #include "InputCoreTypes.h"
 #include "Misc/Paths.h"
-#include "DeviceManager.h"
 
 #define LOCTEXT_NAMESPACE "FWindowsDualsense_ds5wModule"
 
@@ -32,7 +31,6 @@ void FWindowsDualsense_ds5wModule::StartupModule()
 		FSlateApplication::Get().RegisterInputPreProcessor(SonyInputProcessor);
 	}
 #endif
-	
 }
 
 void FWindowsDualsense_ds5wModule::ShutdownModule()
@@ -45,11 +43,10 @@ void FWindowsDualsense_ds5wModule::ShutdownModule()
 		FSlateApplication::Get().UnregisterInputPreProcessor(SonyInputProcessor);
 	}
 #endif
-	
 }
 
 TSharedPtr<IInputDevice> FWindowsDualsense_ds5wModule::CreateInputDevice(
-	const TSharedRef<FGenericApplicationMessageHandler>& InCustomMessageHandler)
+    const TSharedRef<FGenericApplicationMessageHandler>& InCustomMessageHandler)
 {
 	return MakeShareable(new DeviceManager(InCustomMessageHandler));
 }
@@ -69,70 +66,59 @@ void FWindowsDualsense_ds5wModule::RegisterCustomKeys()
 	const FKey PS_PaddleR("PS_PaddleR");
 
 	EKeys::AddKey(FKeyDetails(
-		PS_FunctionL,
-		FText::FromString("PlayStation Left Function Button"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_FunctionL,
+	    FText::FromString("PlayStation Left Function Button"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PS_FunctionR,
-		FText::FromString("PlayStation Right Function Button"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_FunctionR,
+	    FText::FromString("PlayStation Right Function Button"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PS_PaddleL,
-		FText::FromString("PlayStation Left Paddle"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_PaddleL,
+	    FText::FromString("PlayStation Left Paddle"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PS_PaddleR,
-		FText::FromString("PlayStation Right Paddle"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_PaddleR,
+	    FText::FromString("PlayStation Right Paddle"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PS_PushLeftStick,
-		FText::FromString("PlayStation Left Thumbstick Button"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_PushLeftStick,
+	    FText::FromString("PlayStation Left Thumbstick Button"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PS_PushRightStick,
-		FText::FromString("PlayStation Right Thumbstick Button"),
-		FKeyDetails::GamepadKey
-	));
+	    PS_PushRightStick,
+	    FText::FromString("PlayStation Right Thumbstick Button"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		Shared,
-		FText::FromString("PlayStation Share"),
-		FKeyDetails::GamepadKey
-	));
+	    Shared,
+	    FText::FromString("PlayStation Share"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		Menu,
-		FText::FromString("PlayStation Menu"),
-		FKeyDetails::GamepadKey
-	));
+	    Menu,
+	    FText::FromString("PlayStation Menu"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		PlayStationButton,
-		FText::FromString("PlayStation Button"),
-		FKeyDetails::GamepadKey
-	));
+	    PlayStationButton,
+	    FText::FromString("PlayStation Button"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		Mic,
-		FText::FromString("PlayStation Mic"),
-		FKeyDetails::GamepadKey
-	));
+	    Mic,
+	    FText::FromString("PlayStation Mic"),
+	    FKeyDetails::GamepadKey));
 
 	EKeys::AddKey(FKeyDetails(
-		TouchButtom,
-		FText::FromString("PlayStation Touchpad Button"),
-		FKeyDetails::GamepadKey
-	));
+	    TouchButtom,
+	    FText::FromString("PlayStation Touchpad Button"),
+	    FKeyDetails::GamepadKey));
 }
 
 IMPLEMENT_MODULE(FWindowsDualsense_ds5wModule, WindowsDualsense_ds5w)

--- a/Source/WindowsDualsense_ds5w/Public/Core/Algorithms/MadgwickAhrs.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Algorithms/MadgwickAhrs.h
@@ -6,19 +6,19 @@
 class FMadgwickAhrs
 {
 public:
-	FMadgwickAhrs( const float SampleFreq = 200.0f, const float Beta = 0.08f);
+	FMadgwickAhrs(const float SampleFreq = 200.0f, const float Beta = 0.08f);
 
-    // gx,gy,gz in rad/s, ax,ay,az in m/s^2, dt in seconds
-    void UpdateImu(float gx, float gy, float gz, float ax, float ay, float az, float dt);
-    void GetEuler(float &Roll, float &Yaw, float &Pitch);
-    void SetBeta( const float BetaValue);
-	void SetSampleFreq( const float Freq);
-	void GetQuaternion(float &Nq0, float &Nq1, float &Nq2, float &Nq3) const;
+	// gx,gy,gz in rad/s, ax,ay,az in m/s^2, dt in seconds
+	void UpdateImu(float gx, float gy, float gz, float ax, float ay, float az, float dt);
+	void GetEuler(float& Roll, float& Yaw, float& Pitch);
+	void SetBeta(const float BetaValue);
+	void SetSampleFreq(const float Freq);
+	void GetQuaternion(float& Nq0, float& Nq1, float& Nq2, float& Nq3) const;
 
 	void Reset();
 
 private:
-    float Beta;
-    float SampleFreq;
-    float q0, q1, q2, q3;
+	float Beta;
+	float SampleFreq;
+	float q0, q1, q2, q3;
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DeviceRegistry.h
@@ -90,7 +90,7 @@ public:
 	 *                  periodic processing of the device lifecycle and connection state.
 	 */
 	void DetectedChangeConnections(float DeltaTime);
-	
+
 private:
 	/**
 	 * A floating-point variable that represents the change or difference in the accumulator value over time.

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualSense/DualSenseLibrary.h
@@ -4,19 +4,19 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
-#include "UObject/Object.h"
-#include "InputCoreTypes.h"
 #include "Async/TaskGraphInterfaces.h"
+#include "Containers/Queue.h"
+#include "Core/Enums/EDeviceCommons.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
 #include "Core/Interfaces/SonyGamepadTriggerInterface.h"
-#include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
-#include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
-#include "Core/Enums/EDeviceCommons.h"
 #include "Core/Structs/DeviceContext.h"
 #include "Core/Structs/DeviceSettings.h"
 #include "Core/Structs/DualSenseFeatureReport.h"
-#include "Containers/Queue.h"
+#include "CoreMinimal.h"
+#include "InputCoreTypes.h"
+#include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
+#include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
+#include "UObject/Object.h"
 #include <atomic>
 #include "DualSenseLibrary.generated.h"
 
@@ -303,8 +303,7 @@ struct FSensorBounds
  * the DualSense controller programmatically within an application.
  */
 UCLASS()
-class WINDOWSDUALSENSE_DS5W_API UDualSenseLibrary : public UObject, public ISonyGamepadInterface,
-                                                    public ISonyGamepadTriggerInterface
+class WINDOWSDUALSENSE_DS5W_API UDualSenseLibrary : public UObject, public ISonyGamepadInterface, public ISonyGamepadTriggerInterface
 {
 	GENERATED_BODY()
 
@@ -505,8 +504,8 @@ public:
 	 * @param EndStrength The strength of the trigger at the ending position (1-8).
 	 * @param Hand The controller hand (Left, Right, or AnyHand) to apply the effect to.
 	 */
- void SetBow(int32 StartPosition, int32 EndPosition, int32 BegingStrength, int32 EndStrength,
-             const EControllerHand& Hand);
+	void SetBow(int32 StartPosition, int32 EndPosition, int32 BegingStrength, int32 EndStrength,
+	            const EControllerHand& Hand);
 	/**
 	 * Sets machine effects for the DualSense controller's adaptive triggers.
 	 *
@@ -518,15 +517,15 @@ public:
 	 * @param Period The time period of the vibration effect, influencing its duration.
 	 * @param Hand The hand (Left, Right, or AnyHand) to apply the effect to.
 	 */
- void SetMachine(int32 StartPosition, int32 EndPosition, int32 AmplitudeBegin, int32 AmplitudeEnd,
-                 float Frequency, float Period, const EControllerHand& Hand);
+	void SetMachine(int32 StartPosition, int32 EndPosition, int32 AmplitudeBegin, int32 AmplitudeEnd,
+	                float Frequency, float Period, const EControllerHand& Hand);
 
- /**
-  * Advanced rhythmic machine effect (opcode 0x27):
-  * [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
-  */
- void SetMachine27(uint8 StartZone, uint8 BehaviorFlag, uint8 ForceAmplitude, uint8 Period, uint8 Frequency,
-                   const EControllerHand& Hand);
+	/**
+	 * Advanced rhythmic machine effect (opcode 0x27):
+	 * [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
+	 */
+	void SetMachine27(uint8 StartZone, uint8 BehaviorFlag, uint8 ForceAmplitude, uint8 Period, uint8 Frequency,
+	                  const EControllerHand& Hand);
 	/**
 	 * @brief Configures the galloping effect for a controller's trigger.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/DualShock/DualShockLibrary.h
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
-#include "UObject/Object.h"
+#include "Async/TaskGraphInterfaces.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
 #include "Core/Structs/DualShockFeatureReport.h"
-#include "Async/TaskGraphInterfaces.h"
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
 #include "DualShockLibrary.generated.h"
 
 /**
- * 
+ *
  */
 UCLASS()
 class WINDOWSDUALSENSE_DS5W_API UDualShockLibrary : public UObject, public ISonyGamepadInterface
@@ -99,8 +99,8 @@ public:
 	 * @param IsButtonPressed A boolean indicating the current pressed state of the button (true if pressed, false otherwise).
 	 */
 	virtual void CheckButtonInput(const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler,
-								  const FPlatformUserId UserId, const FInputDeviceId InputDeviceId,
-								  const FName ButtonName, const bool IsButtonPressed);
+	                              const FPlatformUserId UserId, const FInputDeviceId InputDeviceId,
+	                              const FName ButtonName, const bool IsButtonPressed);
 	/**
 	 * @brief Updates the input state for a DualSense device.
 	 *
@@ -114,7 +114,7 @@ public:
 	 * @return A boolean value indicating whether the input update was successful.
 	 */
 	virtual void UpdateInput(const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler,
-							 const FPlatformUserId UserId, const FInputDeviceId InputDeviceId, float Delta) override;
+	                         const FPlatformUserId UserId, const FInputDeviceId InputDeviceId, float Delta) override;
 	/**
 	 * Retrieves the current battery level of the DualSense controller.
 	 *
@@ -181,7 +181,7 @@ public:
 	 */
 	virtual EDeviceType GetDeviceType() override
 	{
-		return HIDDeviceContexts.DeviceType;	
+		return HIDDeviceContexts.DeviceType;
 	}
 	/**
 	 * Sets the touch state for the device.
@@ -214,7 +214,7 @@ public:
 	 *                    The value ranges from 0.0 (no progress) to 1.0 (fully calibrated).
 	 * @return True if the calibration status was successfully retrieved, false otherwise.
 	 */
-	virtual bool GetMotionSensorCalibrationStatus(float& OutProgress) override {return false;}
+	virtual bool GetMotionSensorCalibrationStatus(float& OutProgress) override { return false; }
 	/**
 	 * @brief Resets the gyro orientation to its default alignment.
 	 *
@@ -247,6 +247,7 @@ public:
 	 * It is reset during library shutdown to clear all stored button states.
 	 */
 	TMap<const FName, bool> ButtonStates;
+
 protected:
 	/**
 	 * @brief The PlatformInputDeviceMapper is responsible for mapping platform-specific
@@ -267,6 +268,7 @@ protected:
 	 * - Facilitating cross-platform input device compatibility.
 	 */
 	static FGenericPlatformInputDeviceMapper PlatformInputDeviceMapper;
+
 private:
 	/**
 	 * @brief Represents the current battery level of a device.

--- a/Source/WindowsDualsense_ds5w/Public/Core/Enums/EDeviceCommons.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Enums/EDeviceCommons.h
@@ -7,9 +7,9 @@
 #include "CoreMinimal.h"
 #include "EDeviceCommons.generated.h"
 
-#define BTN_FN1          0x10
-#define BTN_FN2          0x20
-#define BTN_PADDLE_LEFT  0x40
+#define BTN_FN1 0x10
+#define BTN_FN2 0x20
+#define BTN_PADDLE_LEFT 0x40
 #define BTN_PADDLE_RIGHT 0x80
 
 #define BTN_DPAD_UP 0x8
@@ -74,7 +74,7 @@ enum class ELedPlayerEnum : uint8
 	One = PLAYER_LED_MIDDLE UMETA(DisplayName = "Player One"),
 	Two = PLAYER_LED_MIDDLE_RIGHT | PLAYER_LED_MIDDLE_LEFT UMETA(DisplayName = "Player Two"),
 	Three = PLAYER_LED_RIGHT | PLAYER_LED_MIDDLE | PLAYER_LED_LEFT UMETA(DisplayName = "Player Three"),
-	All  = PLAYER_LED_RIGHT | PLAYER_LED_MIDDLE_RIGHT | PLAYER_LED_MIDDLE_LEFT | PLAYER_LED_LEFT UMETA(DisplayName = "Player all led")
+	All = PLAYER_LED_RIGHT | PLAYER_LED_MIDDLE_RIGHT | PLAYER_LED_MIDDLE_LEFT | PLAYER_LED_LEFT UMETA(DisplayName = "Player all led")
 };
 
 /**

--- a/Source/WindowsDualsense_ds5w/Public/Core/Enums/EDeviceConnection.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Enums/EDeviceConnection.h
@@ -16,7 +16,7 @@
  * @value DualShock Represents the DualShock device type.
  */
 UENUM(Blueprintable)
-enum EDeviceType: uint8
+enum EDeviceType : uint8
 {
 	DualSense UMETA(DisplayName = "DualSense Default"),
 	DualSenseEdge UMETA(DisplayName = "DualSense Edge"),
@@ -33,7 +33,7 @@ enum EDeviceType: uint8
  * @value Unknown Represents an unknown or unrecognized connection type.
  */
 UENUM(Blueprintable)
-enum EDeviceConnection: uint8
+enum EDeviceConnection : uint8
 {
 	Usb UMETA(DisplayName = "USB"),
 	Bluetooth UMETA(DisplayName = "Bluetooth"),

--- a/Source/WindowsDualsense_ds5w/Public/Core/HapticsRegistry.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/HapticsRegistry.h
@@ -5,93 +5,93 @@
 #pragma once
 #include "Containers/Ticker.h"
 #include "CoreMinimal.h"
-#include "Misc/CoreDelegates.h"
-#include "Templates/SharedPointer.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 #include "Subsystems/AudioHapticsListener.h"
+#include "Templates/SharedPointer.h"
 
 class FHapticsRegistry final : public TSharedFromThis<FHapticsRegistry>, public FNoncopyable
 {
-    /**
-     * Retrieves the singleton instance of the FHapticsRegistry.
-     *
-     * This method ensures that there is only a single shared instance
-     * of FHapticsRegistry available. If the instance has not been created yet,
-     * it initializes and returns a newly created shared instance. This is a thread-safe way
-     * to manage a centralized registry for haptics-related operations.
-     *
-     * @return A shared pointer to the singleton instance of FHapticsRegistry.
-     */
+	/**
+	 * Retrieves the singleton instance of the FHapticsRegistry.
+	 *
+	 * This method ensures that there is only a single shared instance
+	 * of FHapticsRegistry available. If the instance has not been created yet,
+	 * it initializes and returns a newly created shared instance. This is a thread-safe way
+	 * to manage a centralized registry for haptics-related operations.
+	 *
+	 * @return A shared pointer to the singleton instance of FHapticsRegistry.
+	 */
 public:
-    static TSharedPtr<FHapticsRegistry> Get();
-    /**
-     * Creates and associates a new audio haptics listener for a specified input device and submix.
-     *
-     * This method ensures that only one listener is active for the given device. If a listener already exists,
-     * it removes the previous association before creating and registering a new listener for the specified submix.
-     *
-     * @param DeviceId The unique identifier of the input device for which the listener is created.
-     * @param Submix A pointer to the sound submix to which the audio haptics listener will be bound.
-     *               If this is null, the method will return without taking any action.
-     */
-    void CreateListenerForDevice(const FInputDeviceId& DeviceId, USoundSubmix* Submix);
-    /**
-     * Removes the audio haptics listener for the specified input device.
-     *
-     * This method ensures that any existing listener associated with the given
-     * device ID is properly removed and unregistered. If no listener exists for
-     * the provided device ID, the method takes no action.
-     *
-     * @param DeviceId The unique identifier of the input device whose associated
-     *                 haptics listener is to be removed.
-     */
-    void RemoveListenerForDevice(const FInputDeviceId& DeviceId);
-    /**
-     * Destructor for the FHapticsRegistry class.
-     *
-     * Cleans up and releases all resources managed by this instance of FHapticsRegistry.
-     * Specifically, it iterates through all registered listeners in the ControllerListeners map
-     * and ensures that all associated listeners are properly removed.
-     *
-     * This method guarantees that the resources used for managing haptics-related listeners are
-     * de-allocated in a safe and orderly manner, avoiding resource leaks or dangling listeners.
-     */
-    ~FHapticsRegistry();
-    /**
-     * Checks whether there is a registered listener for the specified input device.
-     *
-     * This method determines if an input device, identified by the provided device ID,
-     * has an associated registered listener within the haptics registry.
-     *
-     * @param DeviceId The unique identifier of the input device to check for a listener.
-     * @return True if a listener is registered for the specified device, otherwise false.
-     */
-    bool HasListenerForDevice(const FInputDeviceId& DeviceId) const;
-    /**
-     * Removes all haptics listeners from the registry and unregisters them from the audio device.
-     *
-     * This method iterates through all registered controller listeners, unregisters each from the
-     * audio subsystem, and clears the internal map storing the listeners. It ensures that no
-     * haptics listeners remain after execution and cleans up resources related to submix buffer
-     * listeners when applicable. Compatibility checks are included based on the engine version
-     * to ensure proper handling.
-     */
-    void RemoveAllListeners();
+	static TSharedPtr<FHapticsRegistry> Get();
+	/**
+	 * Creates and associates a new audio haptics listener for a specified input device and submix.
+	 *
+	 * This method ensures that only one listener is active for the given device. If a listener already exists,
+	 * it removes the previous association before creating and registering a new listener for the specified submix.
+	 *
+	 * @param DeviceId The unique identifier of the input device for which the listener is created.
+	 * @param Submix A pointer to the sound submix to which the audio haptics listener will be bound.
+	 *               If this is null, the method will return without taking any action.
+	 */
+	void CreateListenerForDevice(const FInputDeviceId& DeviceId, USoundSubmix* Submix);
+	/**
+	 * Removes the audio haptics listener for the specified input device.
+	 *
+	 * This method ensures that any existing listener associated with the given
+	 * device ID is properly removed and unregistered. If no listener exists for
+	 * the provided device ID, the method takes no action.
+	 *
+	 * @param DeviceId The unique identifier of the input device whose associated
+	 *                 haptics listener is to be removed.
+	 */
+	void RemoveListenerForDevice(const FInputDeviceId& DeviceId);
+	/**
+	 * Destructor for the FHapticsRegistry class.
+	 *
+	 * Cleans up and releases all resources managed by this instance of FHapticsRegistry.
+	 * Specifically, it iterates through all registered listeners in the ControllerListeners map
+	 * and ensures that all associated listeners are properly removed.
+	 *
+	 * This method guarantees that the resources used for managing haptics-related listeners are
+	 * de-allocated in a safe and orderly manner, avoiding resource leaks or dangling listeners.
+	 */
+	~FHapticsRegistry();
+	/**
+	 * Checks whether there is a registered listener for the specified input device.
+	 *
+	 * This method determines if an input device, identified by the provided device ID,
+	 * has an associated registered listener within the haptics registry.
+	 *
+	 * @param DeviceId The unique identifier of the input device to check for a listener.
+	 * @return True if a listener is registered for the specified device, otherwise false.
+	 */
+	bool HasListenerForDevice(const FInputDeviceId& DeviceId) const;
+	/**
+	 * Removes all haptics listeners from the registry and unregisters them from the audio device.
+	 *
+	 * This method iterates through all registered controller listeners, unregisters each from the
+	 * audio subsystem, and clears the internal map storing the listeners. It ensures that no
+	 * haptics listeners remain after execution and cleans up resources related to submix buffer
+	 * listeners when applicable. Compatibility checks are included based on the engine version
+	 * to ensure proper handling.
+	 */
+	void RemoveAllListeners();
 
-    /**
-     * Executes the haptics tick for all registered haptics listeners.
-     *
-     * This method iterates through the map of registered ControllerListeners,
-     * invokes the `ConsumeHapticsQueue` method on valid listeners, and processes
-     * the pending haptic feedback actions. It ensures that haptics data
-     * gets consumed in a timely manner during the game's update cycle.
-     *
-     * @param DeltaTime The time elapsed since the last tick, in seconds.
-     *                  This parameter is generally used for time-based updates.
-     *
-     * @return Always returns true to indicate the tick was successful.
-     */
-    bool Tick(float DeltaTime);
+	/**
+	 * Executes the haptics tick for all registered haptics listeners.
+	 *
+	 * This method iterates through the map of registered ControllerListeners,
+	 * invokes the `ConsumeHapticsQueue` method on valid listeners, and processes
+	 * the pending haptic feedback actions. It ensures that haptics data
+	 * gets consumed in a timely manner during the game's update cycle.
+	 *
+	 * @param DeltaTime The time elapsed since the last tick, in seconds.
+	 *                  This parameter is generally used for time-based updates.
+	 *
+	 * @return Always returns true to indicate the tick was successful.
+	 */
+	bool Tick(float DeltaTime);
 
 	/**
 	 * Handle for a delegate registered to the game thread ticker.
@@ -103,26 +103,26 @@ public:
 	 */
 	FTSTicker::FDelegateHandle GameThreadTickerHandle;
 
-    /**
-     * Holds the singleton instance of FHapticsRegistry.
-     *
-     * This static member variable is used to ensure that only one instance
-     * of the FHapticsRegistry class exists during the application's runtime.
-     * It is initialized the first time the Get() method is called and remains
-     * valid until the application terminates or the instance is explicitly destroyed.
-     */
+	/**
+	 * Holds the singleton instance of FHapticsRegistry.
+	 *
+	 * This static member variable is used to ensure that only one instance
+	 * of the FHapticsRegistry class exists during the application's runtime.
+	 * It is initialized the first time the Get() method is called and remains
+	 * valid until the application terminates or the instance is explicitly destroyed.
+	 */
 private:
-    static TSharedPtr<FHapticsRegistry> Instance;
-    /**
-     * Maps input device identifiers to their associated audio haptics listeners.
-     *
-     * This data structure is responsible for managing the relationship between input devices
-     * (identified by FInputDeviceId) and their corresponding haptics listeners
-     * (represented by TSharedPtr<FAudioHapticsListener>). It ensures that each device
-     * has a corresponding listener, allowing for device-specific haptics handling.
-     *
-     * The map is used primarily within the FHapticsRegistry class to register, retrieve,
-     * and remove audio haptics listeners as devices are added or removed.
-     */
-    TMap<FInputDeviceId, TSharedPtr<FAudioHapticsListener>> ControllerListeners;
+	static TSharedPtr<FHapticsRegistry> Instance;
+	/**
+	 * Maps input device identifiers to their associated audio haptics listeners.
+	 *
+	 * This data structure is responsible for managing the relationship between input devices
+	 * (identified by FInputDeviceId) and their corresponding haptics listeners
+	 * (represented by TSharedPtr<FAudioHapticsListener>). It ensures that each device
+	 * has a corresponding listener, allowing for device-specific haptics handling.
+	 *
+	 * The map is used primarily within the FHapticsRegistry class to register, retrieve,
+	 * and remove audio haptics listeners as devices are added or removed.
+	 */
+	TMap<FInputDeviceId, TSharedPtr<FAudioHapticsListener>> ControllerListeners;
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/PlatformHardwareInfoInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/PlatformHardwareInfoInterface.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Core/Structs/DeviceContext.h"
+#include "CoreMinimal.h"
 
 #define PLATFORM_SONY (PLATFORM_PS4 || PLATFORM_PS5)
 

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadInterface.h
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
-#include "UObject/Interface.h"
 #include "Core/Enums/EDeviceCommons.h"
 #include "Core/Structs/DeviceContext.h"
 #include "Core/Structs/DeviceSettings.h"
+#include "CoreMinimal.h"
 #include "InputCoreTypes.h"
 #include "Misc/CoreDelegates.h"
-#include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
 #include "Runtime/ApplicationCore/Public/GenericPlatform/GenericApplicationMessageHandler.h"
+#include "Runtime/ApplicationCore/Public/GenericPlatform/IInputInterface.h"
+#include "UObject/Interface.h"
 #include "SonyGamepadInterface.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Interfaces/SonyGamepadTriggerInterface.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/Interface.h"
 #include "Templates/SharedPointer.h"
+#include "UObject/Interface.h"
 #include "SonyGamepadTriggerInterface.generated.h"
 
 // This class does not need to be modified.
@@ -17,11 +17,11 @@ class USonyGamepadTriggerInterface : public UInterface
 };
 
 /**
- * 
+ *
  */
 class WINDOWSDUALSENSE_DS5W_API ISonyGamepadTriggerInterface
 {
-    GENERATED_BODY()
+	GENERATED_BODY()
 
 public:
 	/**
@@ -141,15 +141,15 @@ public:
 	 * @param AudioData An array of integer values representing the audio waveform data
 	 *                  used to drive the haptic feedback effects on the triggers.
 	 */
-    virtual void AudioHapticUpdate(TArray<int8> AudioData) = 0;
+	virtual void AudioHapticUpdate(TArray<int8> AudioData) = 0;
 
-    /**
-     * New advanced rhythmic machine effect (opcode 0x27).
-     * Structure: [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
-     * Start_Zone: one-byte zone value (e.g., 0x82, 0x84, 0x80, 0x88)
-     * Behavior_Flag: 1 = EndAtPos, 2 = KeepEffect
-     * Force_Amplitude: High nibble (1-3) = force intensity, Low nibble (10-15) = amplitude level
-     * Period: 0-20, Frequency: 0-40
-     */
-    virtual void SetMachine27(uint8 StartZone, uint8 BehaviorFlag, uint8 ForceAmplitude, uint8 Period, uint8 Frequency, const EControllerHand& Hand) = 0;
+	/**
+	 * New advanced rhythmic machine effect (opcode 0x27).
+	 * Structure: [27] [Start_Zone] [Behavior_Flag] [Force_Amplitude] [Period] [Frequency]
+	 * Start_Zone: one-byte zone value (e.g., 0x82, 0x84, 0x80, 0x88)
+	 * Behavior_Flag: 1 = EndAtPos, 2 = KeepEffect
+	 * Force_Amplitude: High nibble (1-3) = force intensity, Low nibble (10-15) = amplitude level
+	 * Period: 0-20, Frequency: 0-40
+	 */
+	virtual void SetMachine27(uint8 StartZone, uint8 BehaviorFlag, uint8 ForceAmplitude, uint8 Period, uint8 Frequency, const EControllerHand& Hand) = 0;
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/Platforms/Commons/CommonsDeviceInfo.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Platforms/Commons/CommonsDeviceInfo.h
@@ -7,7 +7,7 @@
 #if PLATFORM_WINDOWS
 #else
 #include "Core/Interfaces/PlatformHardwareInfoInterface.h"
-class FCommonsDeviceInfo : public IPlatformHardwareInfoInterface 
+class FCommonsDeviceInfo : public IPlatformHardwareInfoInterface
 {
 	/**
 	 * Virtual destructor for the FCommonsDeviceInfo class.
@@ -20,7 +20,7 @@ class FCommonsDeviceInfo : public IPlatformHardwareInfoInterface
 	 * of derived class objects through base class pointers.
 	 */
 public:
-	virtual ~FCommonsDeviceInfo() override {};
+	virtual ~FCommonsDeviceInfo() override {}
 	/**
 	 * Processes audio haptic feedback using the given device context.
 	 *

--- a/Source/WindowsDualsense_ds5w/Public/Core/Platforms/Windows/WindowsDeviceInfo.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Platforms/Windows/WindowsDeviceInfo.h
@@ -8,13 +8,13 @@
 #define NOMINMAX
 
 #include "Windows/AllowWindowsPlatformTypes.h"
-#include <Windows.h>
 #include "Windows/HideWindowsPlatformTypes.h"
+#include <Windows.h>
 #endif
 
-#include "CoreMinimal.h"
 #include "../../Interfaces/PlatformHardwareInfoInterface.h"
 #include "../../Structs/DeviceContext.h"
+#include "CoreMinimal.h"
 
 /**
  * @brief Enumerates the possible outcomes of a polling operation in HID device communication.
@@ -23,7 +23,8 @@
  * It provides status indicators for successful reads, lack of data in the current tick,
  * transient errors, or disconnected devices.
  */
-enum class EPollResult {
+enum class EPollResult
+{
 	ReadOk,
 	NoIoThisTick,
 	TransientError,
@@ -38,7 +39,7 @@ enum class EPollResult {
  */
 class FWindowsDeviceInfo final : public IPlatformHardwareInfoInterface
 {
-	
+
 public:
 	virtual void ProcessAudioHapitc(FDeviceContext* Context) override;
 	static bool ConfigureBluetoothFeatures(HANDLE DeviceHandle);
@@ -145,15 +146,15 @@ public:
 	{
 		switch (Error)
 		{
-		case ERROR_DEVICE_NOT_CONNECTED:
-		case ERROR_GEN_FAILURE:
-		case ERROR_INVALID_HANDLE:
-		case ERROR_BAD_COMMAND:
-		case ERROR_FILE_NOT_FOUND:
-		case ERROR_ACCESS_DENIED:
-			return true;
-		default:
-			return false;
+			case ERROR_DEVICE_NOT_CONNECTED:
+			case ERROR_GEN_FAILURE:
+			case ERROR_INVALID_HANDLE:
+			case ERROR_BAD_COMMAND:
+			case ERROR_FILE_NOT_FOUND:
+			case ERROR_ACCESS_DENIED:
+				return true;
+			default:
+				return false;
 		}
 	}
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/PlayStationOutputComposer.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/PlayStationOutputComposer.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Core/Structs/DeviceContext.h"
+#include "CoreMinimal.h"
 
 /**
  * @class FPlayStationOutputComposer
@@ -19,7 +19,7 @@
  */
 class WINDOWSDUALSENSE_DS5W_API FPlayStationOutputComposer
 {
-	
+
 public:
 	/**
 	 * @var FPlayStationOutputComposer::CRCSeed

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/DeviceContext.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/DeviceContext.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
-
 #if PLATFORM_WINDOWS
 
 #include "Windows/AllowWindowsPlatformTypes.h"
-#include <Windows.h>
 #include "Windows/HideWindowsPlatformTypes.h"
+#include <Windows.h>
 using FPlatformDeviceHandle = HANDLE;
 #define INVALID_PLATFORM_HANDLE INVALID_HANDLE_VALUE
 
@@ -22,9 +21,9 @@ using FPlatformDeviceHandle = void*;
 #define INVALID_PLATFORM_HANDLE nullptr
 #endif
 
+#include "Core/Enums/EDeviceConnection.h"
 #include "CoreMinimal.h"
 #include "OutputContext.h"
-#include "Core/Enums/EDeviceConnection.h"
 #include "DeviceContext.generated.h"
 
 /**
@@ -203,8 +202,10 @@ struct FDeviceContext
 	// When enabled via console commands, these arrays are copied verbatim into the HID report.
 	bool bOverrideTriggerBytes = false;
 	unsigned char OverrideTriggerRight[10] = {};
-	unsigned char OverrideTriggerLeft[10]  = {};
+	unsigned char OverrideTriggerLeft[10] = {};
 
 	FDeviceContext() = default;
-	explicit FDeviceContext( const FInputDeviceId InUniqueInputDeviceId) : UniqueInputDeviceId(InUniqueInputDeviceId) {}
+	explicit FDeviceContext(const FInputDeviceId InUniqueInputDeviceId)
+	    : UniqueInputDeviceId(InUniqueInputDeviceId)
+	{}
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/DualSenseFeatureReport.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/DualSenseFeatureReport.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Core/Enums/EDeviceCommons.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
+#include "CoreMinimal.h"
 #include "DualSenseFeatureReport.generated.h"
 
 /**
@@ -32,7 +32,7 @@ USTRUCT(BlueprintType)
 struct FDualSenseFeatureReport : public FFeatureReport
 {
 	GENERATED_BODY()
-	
+
 	/**
 	 * Represents the microphone status of the DualSense controller audio settings.
 	 * This variable utilizes the EDualSenseAudioFeatureReport enum to toggle the microphone feature.
@@ -44,7 +44,7 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 *   - EDualSenseAudioFeatureReport::On: Enables the microphone.
 	 *   - EDualSenseAudioFeatureReport::Off: Disables the microphone.
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings")
 	EDualSenseAudioFeatureReport MicStatus;
 	/**
 	 * Specifies the operational state of the audio headset on a DualSense controller.
@@ -61,7 +61,7 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 * - EDualSenseAudioFeatureReport::On: Enables headset audio.
 	 * - EDualSenseAudioFeatureReport::Off: Disables headset audio.
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings")
 	EDualSenseAudioFeatureReport AudioHeadset;
 	/**
 	 * Represents the audio speaker settings for a DualSense device.
@@ -73,7 +73,7 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 * Category: DualSense Settings
 	 * Access: Readable and writable in Blueprints
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings")
 	EDualSenseAudioFeatureReport AudioSpeaker;
 	/**
 	 * Specifies the vibration mode for the DualSense device. Controls the type of haptic feedback
@@ -92,16 +92,13 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 * Display Name: Soft haptic feedback, advanced vibrate
 	 */
 	UPROPERTY(
-		EditAnywhere,
-		BlueprintReadWrite,
-		Category="DualSense Settings",
-		meta=(
-				DisplayName = "Enables vibration mode",
-				ToolTip = "Advanced vibration that are directly generated from real-time audio analysis for a more immersive haptic experience. Note: This feature is only supported when the controller is connected via USB."
-			)
-		)
+	    EditAnywhere,
+	    BlueprintReadWrite,
+	    Category = "DualSense Settings",
+	    meta = (DisplayName = "Enables vibration mode",
+	            ToolTip = "Advanced vibration that are directly generated from real-time audio analysis for a more immersive haptic experience. Note: This feature is only supported when the controller is connected via USB."))
 	EDualSenseDeviceFeatureReport VibrationMode;
-	
+
 	/**
 	 * The microphone volume level for the DualSense device.
 	 *
@@ -116,8 +113,8 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 *   - UIMin: 0
 	 *   - UIMax: 100
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings",
-		meta = (ClampMin = "0", ClampMax = "100", UIMin = "0", UIMax = "100"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings",
+	          meta = (ClampMin = "0", ClampMax = "100", UIMin = "0", UIMax = "100"))
 	int32 MicVolume;
 	/**
 	 * Represents the audio volume setting for a DualSense device.
@@ -136,8 +133,8 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 * - UIMin: 0 (Minimum value shown in UI sliders)
 	 * - UIMax: 100 (Maximum value shown in UI sliders)
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings",
-		meta = (ClampMin = "0", ClampMax = "100", UIMin = "0", UIMax = "100"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings",
+	          meta = (ClampMin = "0", ClampMax = "100", UIMin = "0", UIMax = "100"))
 	int32 AudioVolume;
 
 	/**
@@ -157,8 +154,8 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 * - UIMin: 0
 	 * - UIMax: 15
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings",
-		meta = (ClampMin = "0", ClampMax = "15", UIMin = "0", UIMax = "15"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings",
+	          meta = (ClampMin = "0", ClampMax = "15", UIMin = "0", UIMax = "15"))
 	int32 SoftRumbleReduce;
 	/**
 	 * Specifies the softness level of the adaptive triggers on a DualSense controller.
@@ -175,8 +172,8 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 *
 	 * Category: DualSense Settings
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="DualSense Settings",
-		meta = (ClampMin = "0", ClampMax = "15", UIMin = "0", UIMax = "15"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DualSense Settings",
+	          meta = (ClampMin = "0", ClampMax = "15", UIMin = "0", UIMax = "15"))
 	EDualSenseTriggerSoftnessLevel TriggerSoftnessLevel;
 
 	/**
@@ -187,15 +184,15 @@ struct FDualSenseFeatureReport : public FFeatureReport
 	 *
 	 * @return A default-initialized instance of FDualSenseFeatureReport.
 	 */
-	FDualSenseFeatureReport():
-		MicStatus(EDualSenseAudioFeatureReport::Off)
-		, AudioHeadset(EDualSenseAudioFeatureReport::Off)
-		, AudioSpeaker(EDualSenseAudioFeatureReport::On)
-		, VibrationMode(EDualSenseDeviceFeatureReport::DefaultRumble)
-		, MicVolume(0)
-		, AudioVolume(0)
-		, SoftRumbleReduce(0)
-		, TriggerSoftnessLevel(EDualSenseTriggerSoftnessLevel::Medium)
-		{
-		}
+	FDualSenseFeatureReport()
+	    : MicStatus(EDualSenseAudioFeatureReport::Off)
+	    , AudioHeadset(EDualSenseAudioFeatureReport::Off)
+	    , AudioSpeaker(EDualSenseAudioFeatureReport::On)
+	    , VibrationMode(EDualSenseDeviceFeatureReport::DefaultRumble)
+	    , MicVolume(0)
+	    , AudioVolume(0)
+	    , SoftRumbleReduce(0)
+	    , TriggerSoftnessLevel(EDualSenseTriggerSoftnessLevel::Medium)
+	{
+	}
 };

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/DualShockFeatureReport.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/DualShockFeatureReport.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Core/Interfaces/SonyGamepadInterface.h"
+#include "CoreMinimal.h"
 #include "DualShockFeatureReport.generated.h"
 
 /**

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/OutputContext.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/OutputContext.h
@@ -127,7 +127,7 @@ struct FFeatureConfig
 	 * FeatureMode is used to configure a specific feature mode within the device.
 	 * It is stored as an 8-bit unsigned integer, and its default value is 0xF7.
 	 */
-	uint8_t FeatureMode	  = 0xF7;
+	uint8_t FeatureMode = 0xF7;
 	/**
 	 * @brief Represents the mode or pattern of vibration for a device.
 	 *
@@ -346,7 +346,7 @@ struct FStrengths
 	 * The `Period` variable is used to define the timing intervals for effects, such as in haptic triggers.
 	 * It typically ranges from 0 to 255, with conversions from floating-point values done externally.
 	 */
-	uint8_t  Period = 0;
+	uint8_t Period = 0;
 	/**
 	 * @brief Represents a collection or list of zones that are active within a particular system, application,
 	 *        or context of operation.

--- a/Source/WindowsDualsense_ds5w/Public/DeviceManager.h
+++ b/Source/WindowsDualsense_ds5w/Public/DeviceManager.h
@@ -9,7 +9,6 @@
 #include "IInputDevice.h"
 #include "Subsystems/AudioHapticsListener.h"
 
-
 /**
  * Manages DualSense controllers, providing input and haptic feedback functionality.
  * This class interacts with platform-specific input device frameworks to handle
@@ -27,11 +26,10 @@ public:
 	 * @param InMessageHandler The message handler responsible for capturing and processing input events.
 	 */
 	explicit DeviceManager(
-		const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler
-		);
+	    const TSharedRef<FGenericApplicationMessageHandler>& InMessageHandler);
 	/**
 	 * Called every frame to update Controller-State
-	 * 
+	 *
 	 * @param DeltaTime Time
 	 */
 	virtual void Tick(float DeltaTime) override;

--- a/Source/WindowsDualsense_ds5w/Public/DualSenseProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/DualSenseProxy.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
+#include "Core/Enums/EDeviceCommons.h"
+#include "Core/HapticsRegistry.h"
+#include "Core/Structs/DualSenseFeatureReport.h"
 #include "CoreMinimal.h"
 #include "InputCoreTypes.h"
 #include "SonyGamepadProxy.h"
-#include "Core/HapticsRegistry.h"
-#include "Core/Enums/EDeviceCommons.h"
-#include "Core/Structs/DualSenseFeatureReport.h"
 #include "DualSenseProxy.generated.h"
 
 UENUM(BlueprintType)
@@ -17,13 +17,13 @@ enum class ETriggerForceIntensity : uint8
 {
 	/** No force feedback applied */
 	Disabled = 0x00 UMETA(DisplayName = "Disabled"),
-	
+
 	/** Low intensity force feedback */
 	Low = 0x01 UMETA(DisplayName = "Low (25%)"),
-	
+
 	/** Medium intensity force feedback */
 	Medium = 0x02 UMETA(DisplayName = "Medium (50%)"),
-	
+
 	/** High intensity force feedback */
 	High = 0x03 UMETA(DisplayName = "High (100%)")
 };
@@ -33,16 +33,16 @@ enum class ETriggerPosition : uint8
 {
 	/** No resistance at any position */
 	Off = 0x00 UMETA(DisplayName = "Off (No Resistance)"),
-	
+
 	/** Start position - Beginning of trigger pull (0-25%) */
 	Start = 0x02 UMETA(DisplayName = "Start (0-25%)"),
-	
+
 	/** Middle position - Mid trigger pull (25-50%) */
 	Middle = 0x04 UMETA(DisplayName = "Middle (25-50%)"),
-	
+
 	/** Before End position - Near full pull (50-75%) */
 	BeforeEnd = 0x08 UMETA(DisplayName = "Before End (50-75%)"),
-	
+
 	/** End position - Full trigger pull (75-100%) */
 	End = 0x80 UMETA(DisplayName = "End (75-100%)")
 };
@@ -52,13 +52,13 @@ enum class EDualSenseTriggerAmplitude : uint8
 {
 	/** No amplitude - Effect disabled */
 	None = 0x00 UMETA(DisplayName = "None (0%)"),
-	
+
 	/** Low amplitude - Subtle vibration effect */
 	Low = 0x0A UMETA(DisplayName = "Low (~40%)"),
-	
+
 	/** Medium amplitude - Moderate vibration effect */
 	Medium = 0x0C UMETA(DisplayName = "Medium (~50%)"),
-	
+
 	/** High amplitude - Strong vibration effect */
 	High = 0x0F UMETA(DisplayName = "High (100%)")
 };
@@ -68,7 +68,7 @@ enum class ETriggerEffectBehavior : uint8
 {
 	/** Effect applies only at specified position range */
 	Localized = 0 UMETA(DisplayName = "Localized (Stop at Position)"),
-	
+
 	/** Effect continues until trigger is fully pressed */
 	Sustained = 1 UMETA(DisplayName = "Sustained (Extend to End)")
 };
@@ -132,17 +132,16 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void AutomaticGun(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Begin Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 BeginStrength,
-		UPARAM(DisplayName = "Middle Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 MiddleStrength,
-		UPARAM(DisplayName = "End Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndStrength,
-		EControllerHand Hand,
-		bool KeepEffect,
-		float Frequency = 5.0f
-	);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Begin Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 BeginStrength,
+	    UPARAM(DisplayName = "Middle Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 MiddleStrength,
+	    UPARAM(DisplayName = "End Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndStrength,
+	    EControllerHand Hand,
+	    bool KeepEffect,
+	    float Frequency = 5.0f);
 
 	/**
 	 * @brief Sets the GameCube trigger effect for the specified controller and hand.
@@ -153,11 +152,10 @@ public:
 	 * @param ControllerId The identifier for the DualSense controller to target.
 	 * @param Hand Specifies which hand (left or right) the effect should be applied to.
 	 */
-	UFUNCTION (BlueprintCallable, Category = "DualSense Effects|Game Cube")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects|Game Cube")
 	static void GameCube(
-		int32 ControllerId,
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    EControllerHand Hand);
 
 	/**
 	 * @brief Configures custom trigger effects for a PlayStation DualSense controller.
@@ -170,12 +168,11 @@ public:
 	 * @param HexBytes An array of hexadecimal byte strings representing the desired trigger configuration.
 	 *                 Maximum of 10 byte strings is permitted.
 	 */
-	UFUNCTION (BlueprintCallable, Category = "DualSense Effects")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void CustomTrigger(
-		int32 ControllerId,
-		EControllerHand Hand,
-		const TArray<FString>& HexBytes
-	);
+	    int32 ControllerId,
+	    EControllerHand Hand,
+	    const TArray<FString>& HexBytes);
 
 	/**
 	 * Sets haptic feedback for a DualSense controller.
@@ -188,15 +185,14 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void SetFeedback(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Begin Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 BeginStrength,
-		UPARAM(DisplayName = "Middle Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 MiddleStrength,
-		UPARAM(DisplayName = "End Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndStrength,
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Begin Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 BeginStrength,
+	    UPARAM(DisplayName = "Middle Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 MiddleStrength,
+	    UPARAM(DisplayName = "End Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndStrength,
+	    EControllerHand Hand);
 
 	/**
 	 * Applies a resistance effect to the trigger of a PlayStation DualSense controller.
@@ -213,16 +209,15 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void Resistance(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Start Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(DisplayName = "End Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndPosition,
-		UPARAM(DisplayName = "Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 Strength,
-		
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Start Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(DisplayName = "End Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndPosition,
+	    UPARAM(DisplayName = "Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 Strength,
+
+	    EControllerHand Hand);
 
 	/**
 	 * Applies a continuous resistance effect on the adaptive trigger of a DualSense controller.
@@ -234,14 +229,13 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void ContinuousResistance(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Start Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(DisplayName = "Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 Strength,
-		
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Start Position min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(DisplayName = "Strength min: 0 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 Strength,
+
+	    EControllerHand Hand);
 
 	/**
 	 * Configures the bow effect on a DualSense controller.
@@ -255,19 +249,17 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void Bow(
-		int32 ControllerId,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndPosition,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 BeginStrength,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndStrength,
-		
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndPosition,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 BeginStrength,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndStrength,
 
+	    EControllerHand Hand);
 
 	/**
 	 * @brief Triggers a galloping vibration effect on a DualSense controller.
@@ -286,20 +278,18 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void Galloping(
-		int32 ControllerId,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "9", UIMin = "0", UIMax = "9"))
-		int32 EndPosition,
-		UPARAM(DisplayName = "First Foot min: 2 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 FirstFoot,
-		UPARAM(DisplayName = "Second Foot min: (Greater FirstFoot) max: 9", meta = (ClampMin = "0", ClampMax = "9", UIMin = "0", UIMax = "9"))
-		int32 SecondFoot,
-		UPARAM(DisplayName = "Frequency Example: 5.0", meta = (ClampMin = "0.0", ClampMax = "40.0", UIMin = "0.0", UIMax = "40.0"))
-		float Frequency,
-		
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "9", UIMin = "0", UIMax = "9"))
+	        int32 EndPosition,
+	    UPARAM(DisplayName = "First Foot min: 2 max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 FirstFoot,
+	    UPARAM(DisplayName = "Second Foot min: (Greater FirstFoot) max: 9", meta = (ClampMin = "0", ClampMax = "9", UIMin = "0", UIMax = "9"))
+	        int32 SecondFoot,
+	    UPARAM(DisplayName = "Frequency Example: 5.0", meta = (ClampMin = "0.0", ClampMax = "40.0", UIMin = "0.0", UIMax = "40.0")) float Frequency,
+
+	    EControllerHand Hand);
 
 	/**
 	 * Configures and applies machine-like haptic effects to the DualSense controller.
@@ -313,26 +303,23 @@ public:
 	 * @param Period The period of the haptic cycle in seconds.
 	 * @param Hand Specifies which hand the effect is directed towards (left or right).
 	 */
-UE_DEPRECATED(
-	5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Machine instead of EffectMachine.")
- UFUNCTION(BlueprintCallable, Category = "DualSense Effects", meta=(DeprecatedFunction, DeprecationMessage="Use MachineAdvanced (0x27) instead"))
- static void Machine(
-		int32 ControllerId,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndPosition,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 FirstFoot,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 LasFoot,
-		UPARAM(meta = (ClampMin = "0.015", ClampMax = "1.0", UIMin = "0.01", UIMax = "1.0"))
-		float Frequency,
-		UPARAM(meta = (ClampMin = "0.015", ClampMax = "1.0", UIMin = "0.01", UIMax = "1.0"))
-		float Period,
-		
-		EControllerHand Hand
-	);
+	UE_DEPRECATED(
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Machine instead of EffectMachine.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects", meta = (DeprecatedFunction, DeprecationMessage = "Use MachineAdvanced (0x27) instead"))
+	static void Machine(
+	    int32 ControllerId,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndPosition,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 FirstFoot,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 LasFoot,
+	    UPARAM(meta = (ClampMin = "0.015", ClampMax = "1.0", UIMin = "0.01", UIMax = "1.0")) float Frequency,
+	    UPARAM(meta = (ClampMin = "0.015", ClampMax = "1.0", UIMin = "0.01", UIMax = "1.0")) float Period,
+
+	    EControllerHand Hand);
 
 	/**
 	 * Novo efeito Machine avançado (opcode 0x27).
@@ -342,17 +329,16 @@ UE_DEPRECATED(
 	 * Force_Amplitude: High nibble (1-3) = ETriggerForceIntensity, Low nibble (10-15) = EDualSenseTriggerAmplitude
 	 * Period: 0-20, Frequency: 0-40
 	 */
-	UFUNCTION(BlueprintCallable, Category = "DualSense Effects", meta=(DisplayName="Machine Advanced (0x27)"))
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects", meta = (DisplayName = "Machine Advanced (0x27)"))
 	static void MachineAdvanced(
-		int32 ControllerId,
-		ETriggerPosition StartZone,
-		ETriggerEffectBehavior Behavior,
-		ETriggerForceIntensity ForceIntensity,
-		EDualSenseTriggerAmplitude Amplitude,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "20", UIMin = "0", UIMax = "20")) int32 Period,
-		UPARAM(meta = (ClampMin = "0", ClampMax = "40", UIMin = "0", UIMax = "40")) int32 Frequency,
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    ETriggerPosition StartZone,
+	    ETriggerEffectBehavior Behavior,
+	    ETriggerForceIntensity ForceIntensity,
+	    EDualSenseTriggerAmplitude Amplitude,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "20", UIMin = "0", UIMax = "20")) int32 Period,
+	    UPARAM(meta = (ClampMin = "0", ClampMax = "40", UIMin = "0", UIMax = "40")) int32 Frequency,
+	    EControllerHand Hand);
 
 	/**
 	 * Configures a weapon effect on the DualSense controller using specified parameters.
@@ -365,16 +351,15 @@ UE_DEPRECATED(
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects")
 	static void Weapon(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Start Position min: 2", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 StartPosition,
-		UPARAM(DisplayName = "End Position max: 7", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 EndPosition,
-		UPARAM(DisplayName = "Strength max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
-		int32 Strength,
-		
-		EControllerHand Hand
-	);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Start Position min: 2", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 StartPosition,
+	    UPARAM(DisplayName = "End Position max: 7", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 EndPosition,
+	    UPARAM(DisplayName = "Strength max: 8", meta = (ClampMin = "0", ClampMax = "8", UIMin = "0", UIMax = "8"))
+	        int32 Strength,
+
+	    EControllerHand Hand);
 
 	/**
 	 * Controls the LED player light effects on the DualSense controller.
@@ -394,8 +379,8 @@ UE_DEPRECATED(
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Reset Effects")
 	static void NoResistance(int32 ControllerId,
-	
-		EControllerHand Hand);
+
+	                         EControllerHand Hand);
 
 	/**
 	 * Stops the trigger effect on a specific controller for the specified hand.
@@ -405,8 +390,8 @@ UE_DEPRECATED(
 	 */
 	UFUNCTION(BlueprintCallable, Category = "DualSense Reset Effects")
 	static void StopTriggerEffect(int32 ControllerId,
-	
-		EControllerHand HandStop);
+
+	                              EControllerHand HandStop);
 
 	/**
 	 * Stops all trigger effects currently active for the specified DualSense controller.
@@ -426,7 +411,6 @@ UE_DEPRECATED(
 	UFUNCTION(BlueprintCallable, Category = "DualSense Reset Effects")
 	static void ResetEffects(int32 ControllerId);
 
-
 	/**
 	 * Deprecated method for enabling or disabling touch functionality on a DualSense controller.
 	 * This method has been replaced by EnableTouch and is retained for backward compatibility.
@@ -435,9 +419,9 @@ UE_DEPRECATED(
 	 * @param bEnableTouch A boolean value indicating whether to enable (true) or disable (false) the touch functionality.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use EnableTouch instead of EnableTouch1.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Touch Pad",
-		meta=(DeprecatedFunction, DeprecationMessage="Use EnableTouch"))
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use EnableTouch instead of EnableTouch1.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Touch Pad",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use EnableTouch"))
 	static void EnableTouch1(int32 ControllerId, bool bEnableTouch)
 	{
 		EnableTouch(ControllerId, bEnableTouch);
@@ -455,18 +439,17 @@ UE_DEPRECATED(
 	 * @param KeepEffect Whether the effect should persist after the initial application.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use AutomaticGun instead of SetTriggerHapticFeedbackEffect.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use AutomaticGun"))
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use AutomaticGun instead of SetTriggerHapticFeedbackEffect.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use AutomaticGun"))
 	static void SetTriggerHapticFeedbackEffect(
-		int32 ControllerId,
-		int32 StartPosition,
-		int32 BeginStrength,
-		int32 MiddleStrength,
-		int32 EndStrength,
-		
-		EControllerHand Hand, bool KeepEffect
-	)
+	    int32 ControllerId,
+	    int32 StartPosition,
+	    int32 BeginStrength,
+	    int32 MiddleStrength,
+	    int32 EndStrength,
+
+	    EControllerHand Hand, bool KeepEffect)
 	{
 		AutomaticGun(ControllerId, BeginStrength, MiddleStrength, EndStrength, Hand, KeepEffect);
 	}
@@ -479,9 +462,9 @@ UE_DEPRECATED(
 	 * @param bEnableTouch A boolean value indicating whether to enable (true) or disable (false) the touch pad.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use EnableTouch instead of EnableTouch2.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Touch Pad",
-		meta=(DeprecatedFunction, DeprecationMessage="Use EnableTouch"))
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use EnableTouch instead of EnableTouch2.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Touch Pad",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use EnableTouch"))
 	static void EnableTouch2(int32 ControllerId, bool bEnableTouch)
 	{
 		EnableTouch(ControllerId, bEnableTouch);
@@ -501,12 +484,12 @@ UE_DEPRECATED(
 	 * @param Hand The hand (left or right) associated with the controller.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Machine instead of EffectMachine.")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Machine instead of EffectMachine.")
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use Machine"))
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use Machine"))
 	static void EffectMachine(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 FirstFoot,
 	                          int32 LasFoot, float Frequency, float Period,
-	                          
+
 	                          EControllerHand Hand)
 	{
 	}
@@ -524,9 +507,9 @@ UE_DEPRECATED(
 	 * @param Hand The hand (left or right) associated with the controller for the effect.
 	 */
 	UE_DEPRECATED(5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Bow instead of EffectBow.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Effects", meta=(DeprecatedFunction, DeprecationMessage="Use Bow"))
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects", meta = (DeprecatedFunction, DeprecationMessage = "Use Bow"))
 	static void EffectBow(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 BeginStrength, int32 EndStrength,
-	
+
 	                      EControllerHand Hand)
 	{
 		Bow(ControllerId, StartPosition, EndPosition, BeginStrength, EndStrength, Hand);
@@ -540,10 +523,10 @@ UE_DEPRECATED(
 	 * @param Hand The hand (left or right) associated with the controller.
 	 */
 	UE_DEPRECATED(
-		5.1,
-		"Methods refactored and deprecated as of plugin version v1.2.1. Use EffectNoResistance instead of EffectNoResitance.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Reset Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use NoResistance"))
+	    5.1,
+	    "Methods refactored and deprecated as of plugin version v1.2.1. Use EffectNoResistance instead of EffectNoResitance.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Reset Effects",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use NoResistance"))
 	static void EffectNoResitance(int32 ControllerId, EControllerHand Hand)
 	{
 		NoResistance(ControllerId, Hand);
@@ -562,10 +545,10 @@ UE_DEPRECATED(
 	 * @deprecated Use Resistance instead.
 	 */
 	UE_DEPRECATED(
-		5.1,
-		"Methods refactored and deprecated as of plugin version v1.2.1. Use Resistance instead of EffectSectionResitance.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use Resistance"))
+	    5.1,
+	    "Methods refactored and deprecated as of plugin version v1.2.1. Use Resistance instead of EffectSectionResitance.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use Resistance"))
 	static void EffectSectionResitance(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 Strength,
 	                                   EControllerHand ResistanceHand)
 	{
@@ -582,10 +565,10 @@ UE_DEPRECATED(
 	 * @param ContinuousHand The hand (left or right) for which the continuous resistance effect is applied.
 	 */
 	UE_DEPRECATED(
-		5.1,
-		"Methods refactored and deprecated as of plugin version v1.2.1. Use ContinuousResistance instead of EffectContinuousResitance.")
-	UFUNCTION(BlueprintCallable, Category="DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use ContinuousResistance"))
+	    5.1,
+	    "Methods refactored and deprecated as of plugin version v1.2.1. Use ContinuousResistance instead of EffectContinuousResitance.")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use ContinuousResistance"))
 	static void EffectContinuousResitance(int32 ControllerId, int32 StartPosition, int32 Strength,
 	                                      EControllerHand ContinuousHand)
 	{
@@ -603,9 +586,9 @@ UE_DEPRECATED(
 	 * @param Hand The hand (left or right) to which the effect should be applied on the controller.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Weapon instead of EffectWeapon.")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Weapon instead of EffectWeapon.")
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use Weapon"))
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use Weapon"))
 	static void EffectWeapon(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 Strength,
 	                         EControllerHand Hand)
 	{
@@ -626,16 +609,14 @@ UE_DEPRECATED(
 	 * @param Hand The controller hand (left or right).
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Galloping instead of EffectGalloping.")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1. Use Galloping instead of EffectGalloping.")
 	UFUNCTION(BlueprintCallable, Category = "DualSense Effects",
-		meta=(DeprecatedFunction, DeprecationMessage="Use Galloping"))
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use Galloping"))
 	static void EffectGalloping(int32 ControllerId, int32 StartPosition, int32 EndPosition, int32 BeginStrength,
 	                            int32 EndStrength, float Frequency, EControllerHand Hand)
 	{
 		Galloping(ControllerId, StartPosition, EndPosition, BeginStrength, EndStrength, Frequency, Hand);
 	}
-
-	
 
 	/**
 	 * Sets the vibration for a DualSense controller based on audio envelopes and other parameters.
@@ -651,19 +632,18 @@ UE_DEPRECATED(
 	 * @param BaseMultiplier A base multiplier applied to vibration for additional scaling.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.18. Use RegisterSubmixForDevice(int32 ControllerId, USoundSubmix* Submix).")
-	UFUNCTION(BlueprintCallable, Category = "DualSense Audio Vibration", meta=(DeprecatedFunction, DeprecationMessage="Use RegisterSubmixForDevice(int32 ControllerId, USoundSubmix* Submix)"))
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.18. Use RegisterSubmixForDevice(int32 ControllerId, USoundSubmix* Submix).")
+	UFUNCTION(BlueprintCallable, Category = "DualSense Audio Vibration", meta = (DeprecatedFunction, DeprecationMessage = "Use RegisterSubmixForDevice(int32 ControllerId, USoundSubmix* Submix)"))
 	void SetVibrationFromAudio(
-		const int32 ControllerId,
-		const float AverageEnvelopeValue,
-		const float MaxEnvelopeValue,
-		const int32 NumWaveInstances,
-		float EnvelopeToVibrationMultiplier,
-		float PeakToVibrationMultiplier,
-		float Threshold,
-		float ExponentCurve,
-		float BaseMultiplier
-	)
+	    const int32 ControllerId,
+	    const float AverageEnvelopeValue,
+	    const float MaxEnvelopeValue,
+	    const int32 NumWaveInstances,
+	    float EnvelopeToVibrationMultiplier,
+	    float PeakToVibrationMultiplier,
+	    float Threshold,
+	    float ExponentCurve,
+	    float BaseMultiplier)
 	{
 	}
 
@@ -690,7 +670,4 @@ UE_DEPRECATED(
 	{
 		return 0;
 	}
-
-	
-	
 };

--- a/Source/WindowsDualsense_ds5w/Public/Helpers/CommandHelpers.h
+++ b/Source/WindowsDualsense_ds5w/Public/Helpers/CommandHelpers.h
@@ -42,6 +42,4 @@ private:
 	static ISonyGamepadInterface* GetGamepad(const FInputDeviceId& DeviceId);
 	static uint8 ClampByte(int32 V) { return static_cast<uint8>(FMath::Clamp(V, 0, 255)); }
 	static bool ParseHexByte(const FString& Token, uint8& OutByte);
-
-	
 };

--- a/Source/WindowsDualsense_ds5w/Public/Helpers/ValidateHelpers.h
+++ b/Source/WindowsDualsense_ds5w/Public/Helpers/ValidateHelpers.h
@@ -76,7 +76,7 @@ public:
 		{
 			HexString += FString::Printf(TEXT("%02X "), Buffer[i]);
 		}
-		
+
 		UE_LOG(LogTemp, Log, TEXT("Buffer Device: %s String: %s"), *Device, *HexString);
 	}
 
@@ -99,28 +99,43 @@ public:
 		{
 			S.RightChopInline(2);
 		}
-		if (S.IsEmpty()) { OutByte = 0; return false; }
+		if (S.IsEmpty())
+		{
+			OutByte = 0;
+			return false;
+		}
 		for (int32 i = 0; i < S.Len(); ++i)
 		{
 			TCHAR C = S[i];
 			if (!((C >= '0' && C <= '9') || (C >= 'a' && C <= 'f') || (C >= 'A' && C <= 'F')))
 			{
-				OutByte = 0; return false;
+				OutByte = 0;
+				return false;
 			}
 		}
 		// Only allow 1-2 hex chars per token after optional 0x prefix
 		if (S.Len() < 1 || S.Len() > 2)
 		{
-			OutByte = 0; return false;
+			OutByte = 0;
+			return false;
 		}
 		int32 Value = 0;
 		for (int32 i = 0; i < S.Len(); ++i)
 		{
 			TCHAR C = S[i];
 			int32 Nibble = 0;
-			if (C >= '0' && C <= '9') Nibble = C - '0';
-			else if (C >= 'a' && C <= 'f') Nibble = 10 + (C - 'a');
-			else if (C >= 'A' && C <= 'F') Nibble = 10 + (C - 'A');
+			if (C >= '0' && C <= '9')
+			{
+				Nibble = C - '0';
+			}
+			else if (C >= 'a' && C <= 'f')
+			{
+				Nibble = 10 + (C - 'a');
+			}
+			else if (C >= 'A' && C <= 'F')
+			{
+				Nibble = 10 + (C - 'A');
+			}
 			Value = (Value << 4) | (Nibble & 0xF);
 		}
 		OutByte = static_cast<uint8>(Value & 0xFF);

--- a/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/SonyGamepadProxy.h
@@ -4,15 +4,14 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
-#include "UObject/Object.h"
 #include "Core/Enums/EDeviceCommons.h"
 #include "Core/Enums/EDeviceConnection.h"
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
 #if PLATFORM_WINDOWS
 #include "Windows/WindowsApplication.h"
 #endif
 #include "SonyGamepadProxy.generated.h"
-
 
 /**
  * Proxy class for interacting with Sony gamepad devices such as DualSense or DualShock controllers.
@@ -24,7 +23,6 @@ UCLASS(Blueprintable, BlueprintType)
 class WINDOWSDUALSENSE_DS5W_API USonyGamepadProxy : public UObject
 {
 	GENERATED_BODY()
-	
 
 public:
 	/**
@@ -75,13 +73,12 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Led Effects")
 	static void LedColorEffects(
-		int32 ControllerId,
-		FColor Color,
-		UPARAM(DisplayName = "(DualShock 4) LED brightness transition time min: 0.0f max: 2.5f", meta = (ClampMin = "0.0", ClampMax = "2.5", UIMin = "0.0", UIMax = "2.5", ToolTip = "(DualShock) LED brightness transition time, in seconds."))
-		const float BrightnessTime = 0.0f,
-		UPARAM(DisplayName = "(DualShock 4) Toggle transition time min: 0.0f max: 2.5f",  meta = (ClampMin = "0.0", ClampMax = "2.5", UIMin = "0.0", UIMax = "2.5", ToolTip = "(DualShock) Toggle transition time, in seconds."))
-		const float ToogleTime = 0.0f
-	);
+	    int32 ControllerId,
+	    FColor Color,
+	    UPARAM(DisplayName = "(DualShock 4) LED brightness transition time min: 0.0f max: 2.5f", meta = (ClampMin = "0.0", ClampMax = "2.5", UIMin = "0.0", UIMax = "2.5", ToolTip = "(DualShock) LED brightness transition time, in seconds."))
+	        const float BrightnessTime = 0.0f,
+	    UPARAM(DisplayName = "(DualShock 4) Toggle transition time min: 0.0f max: 2.5f", meta = (ClampMin = "0.0", ClampMax = "2.5", UIMin = "0.0", UIMax = "2.5", ToolTip = "(DualShock) Toggle transition time, in seconds."))
+	        const float ToogleTime = 0.0f);
 	/**
 	 * Controls the LED and microphone visual effects on a DualSense controller.
 	 *
@@ -100,14 +97,11 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
 	static void StartMotionSensorCalibration(
-		int32 ControllerId,
-		UPARAM(DisplayName = "Calibration Duration (Seconds)", meta = (ClampMin = "1.0", ClampMax = "10.0", UIMin = "1.0", UIMax = "10.0", 
-			ToolTip = "The time in seconds to collect sensor data for calculating the stable center (baseline). Longer durations can provide a more accurate baseline."))
-			float Duration = 2.0f,
-			UPARAM(DisplayName = "Noise Deadzone Percentage", meta = (ClampMin = "0.0", ClampMax = "1.0", UIMin = "0.0", UIMax = "1.0", 
-				ToolTip = "A percentage (0.0 to 1.0) of the sensor noise range to ignore after calibration. A higher value creates a larger deadzone, filtering out more residual noise but potentially ignoring very subtle movements."))
-				float DeadZone = 0.5f
-			);
+	    int32 ControllerId,
+	    UPARAM(DisplayName = "Calibration Duration (Seconds)", meta = (ClampMin = "1.0", ClampMax = "10.0", UIMin = "1.0", UIMax = "10.0",
+	                                                                   ToolTip = "The time in seconds to collect sensor data for calculating the stable center (baseline). Longer durations can provide a more accurate baseline.")) float Duration = 2.0f,
+	    UPARAM(DisplayName = "Noise Deadzone Percentage", meta = (ClampMin = "0.0", ClampMax = "1.0", UIMin = "0.0", UIMax = "1.0",
+	                                                              ToolTip = "A percentage (0.0 to 1.0) of the sensor noise range to ignore after calibration. A higher value creates a larger deadzone, filtering out more residual noise but potentially ignoring very subtle movements.")) float DeadZone = 0.5f);
 
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad|Motion Sensors")
 	static void ResetGyroOrientation(int32 ControllerId);
@@ -147,9 +141,9 @@ public:
 	 * @param OldUser The ID of the previous user who was associated with the gamepad.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.1.")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.1.")
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Remap Device from User",
-		meta=(DeprecatedFunction, DeprecationMessage="Use GamepadCoOp Plugin"))
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use GamepadCoOp Plugin"))
 	static void RemapControllerIdToUser(int32 GamepadId, int32 UserId, int32 OldUser) {}
 
 	/**
@@ -161,9 +155,9 @@ public:
 	 * @return Returns true if the controller was successfully reconnected, false otherwise.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.10")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.10")
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status",
-		meta=(DeprecatedFunction, DeprecationMessage="Use GamepadCoOp Plugin"))
+	          meta = (DeprecatedFunction, DeprecationMessage = "Use GamepadCoOp Plugin"))
 	static bool DeviceReconnect(int32 ControllerId) { return true; }
 
 	/**
@@ -174,10 +168,10 @@ public:
 	 * @return true if the disconnection was initiated successfully.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.10")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.10")
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Status",
-		meta=(DeprecatedFunction, DeprecationMessage="SonyGamepad: Dualsense or DualShock Status"))
-	static bool DeviceDisconnect(int32 ControllerId) { return true; };
+	          meta = (DeprecatedFunction, DeprecationMessage = "SonyGamepad: Dualsense or DualShock Status"))
+	static bool DeviceDisconnect(int32 ControllerId) { return true; }
 
 	/**
 	 * Enables or disables accelerometer values for the specified controller.
@@ -190,7 +184,7 @@ public:
 	 * @param bEnableAccelerometer A boolean value that determines whether to enable or disable accelerometer values.
 	 */
 	UE_DEPRECATED(
-		5.1, "Methods refactored and deprecated as of plugin version v1.2.14")
+	    5.1, "Methods refactored and deprecated as of plugin version v1.2.14")
 	UFUNCTION(BlueprintCallable, Category = "SonyGamepad: Dualsense or DualShock Touch, Use EnableGyroscopeValues")
 	static void EnableAccelerometerValues(int32 ControllerId, bool bEnableAccelerometer)
 	{
@@ -200,5 +194,4 @@ public:
 protected:
 	UFUNCTION()
 	static FInputDeviceId GetGamepadInterface(int32 ControllerId);
-	
 };

--- a/Source/WindowsDualsense_ds5w/Public/Subsystems/AudioHapticsListener.h
+++ b/Source/WindowsDualsense_ds5w/Public/Subsystems/AudioHapticsListener.h
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "AudioResampler.h"
-#include "ISubmixBufferListener.h"
 #include "Containers/Queue.h"
 #include "Core/Structs/DeviceContext.h"
+#include "CoreMinimal.h"
+#include "ISubmixBufferListener.h"
 
 /**
  Class responsible for handling audio submix buffers and preparing audio data for haptic feedback systems.
- 
+
  FAudioHapticsListener integrates with the audio rendering pipeline using the ISubmixBufferListener interface,
  allowing real-time access to submix audio buffers. The class supports processing, conversion, and resampling
  of audio data for use in haptic feedback hardware or systems. It includes mechanisms to manage resampling state
@@ -23,7 +23,7 @@ class FAudioHapticsListener : public ISubmixBufferListener
 	/**
 	 Constructor for the FAudioHapticsListener class, initializing the listener with the given input device ID
 	 and audio submix reference.
-	 
+
 	 @param InDeviceId The identifier for the input device associated with this haptics listener.
 	 @param InSubmix Pointer to the USoundSubmix object that this listener processes audio data from.
 	 @return An instance of FAudioHapticsListener initialized with the provided input device ID and submix reference.
@@ -33,11 +33,11 @@ public:
 
 	/**
 	 Determines if the audio processing system is actively rendering audio.
-	 
+
 	 This method indicates whether the audio data rendering pipeline is currently active.
 	 It is used to verify the state of the audio system and ensure that audio buffers
 	 are being processed and rendered correctly.
-	 
+
 	 @return True if the system is rendering audio; otherwise, false.
 	 */
 	virtual bool IsRenderingAudio() const override
@@ -47,11 +47,11 @@ public:
 
 	/**
 	 Processes and consumes the current audio data in the haptics queue, sending it to the appropriate haptic feedback interface.
-	 
+
 	 This method retrieves audio packets from the internal queue and forwards them to a supported haptic feedback system, such as
 	 the Sony DualSense gamepad, through the relevant interface. Packets that could not be processed are discarded after the final
 	 flush of the queue.
-	 
+
 	 It integrates with device-specific haptic systems using interfaces like ISonyGamepadTriggerInterface to achieve real-time
 	 audio-haptic feedback conversion.
 	 */
@@ -59,18 +59,18 @@ public:
 
 	/**
 	 Returns the associated audio submix instance.
-	 
+
 	 This method retrieves the `USoundSubmix` object associated with the audio processing pipeline.
 	 The submix serves as a source of mixed audio data, which is utilized in various processing
 	 stages, including resampling and preparation for haptic feedback systems.
-	 
+
 	 @return The `USoundSubmix` instance associated with the haptic feedback audio processing system.
 	 */
 	USoundSubmix* GetSubmix() const
 	{
 		return Submix;
 	}
-	
+
 	/**
 	Called when a new buffer has been rendered for a given submix
 	@param OwningSubmix	The submix object which has rendered a new buffer
@@ -83,7 +83,7 @@ public:
 	virtual void OnNewSubmixBuffer(const USoundSubmix* OwningSubmix, float* AudioData, int32 NumSamples, int32 NumChannels, const int32 SampleRate, double AudioClock) override;
 	/**
 	 A thread-safe queue used for storing audio packets to be processed within the audio rendering pipeline.
-	 
+
 	 AudioPacketQueue is implemented as a multiple-producer single-consumer (MPSC) queue, allowing audio packets
 	 to be enqueued by multiple threads and dequeued by a single consumer thread. This design is optimized for
 	 high-performance, concurrent audio processing workflows. The queue holds arrays of int8, which represent
@@ -94,7 +94,7 @@ private:
 	TQueue<TArray<int8>, EQueueMode::Spsc> AudioPacketQueue;
 	/**
 	 A buffer used to store audio data that has been resampled for haptic feedback systems.
-	 
+
 	 ResampledAudioBuffer is a temporary storage array that holds audio frames after being processed
 	 and converted to a target sample rate using the resampling pipeline. Its size is dynamically
 	 adjusted based on input and output requirements during the resampling operation. This buffer serves
@@ -104,7 +104,7 @@ private:
 	TArray<float> ResampledAudioBuffer;
 	/**
 	 A unique pointer to an FResampler instance used for processing and resampling audio data within the haptic feedback pipeline.
-	 
+
 	 ResamplerImpl manages the audio resampling required to match the desired sample rate for haptic feedback systems.
 	 The resampling process ensures that audio data is appropriately converted from its original rate to a lower haptic-compatible rate.
 	 It supports initializing the resampling method, processing the mono audio data, and writing the resampled output for further use.
@@ -113,7 +113,7 @@ private:
 
 	/**
 	 A reference to a USoundSubmix instance used within the audio processing pipeline.
-	 
+
 	 Submix is a core component that represents an audio submix, allowing for the mixing of multiple audio sources
 	 into a single stream. Within the context of the haptic feedback system, this reference is used to monitor and
 	 access generated audio buffers. The submix provides the necessary audio data for subsequent processing, such as
@@ -122,7 +122,7 @@ private:
 	USoundSubmix* Submix;
 	/**
 	 A unique identifier representing an input device.
-	 
+
 	 DeviceId is used to reliably reference and interact with a specific input device
 	 within the system, such as game controllers or other haptics-enabled peripherals.
 	 It provides a consistent and unique mechanism for identifying devices, enabling
@@ -131,7 +131,7 @@ private:
 	FInputDeviceId DeviceId;
 	/**
 	 Variable used to maintain the state of the left channel for a low-pass filter.
-	 
+
 	 This state is utilized in the filtering process to ensure continuity and accuracy
 	 in audio signal processing, particularly when applying a low-pass effect for the
 	 left audio channel. It is updated dynamically as the audio processing pipeline executes.
@@ -140,7 +140,7 @@ private:
 
 	/**
 	 A floating-point variable used to maintain the internal state of the low-pass filter for the right audio channel.
-	 
+
 	 This variable is utilized in audio signal processing to store the current state of the filter between processing iterations,
 	 ensuring continuity and accuracy in the filtering process. It plays a role in smoothing out high-frequency components
 	 in the right channel audio signal based on the filter's cutoff frequency.

--- a/Source/WindowsDualsense_ds5w/Public/Subsystems/SonyInputProcessor.h
+++ b/Source/WindowsDualsense_ds5w/Public/Subsystems/SonyInputProcessor.h
@@ -5,24 +5,23 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Framework/Application/IInputProcessor.h"
 #include "Input/Events.h"
 #include "InputCoreTypes.h"
-#include "Framework/Application/IInputProcessor.h"
 
 class FSonyInputProcessor : public IInputProcessor
 {
 public:
 	virtual ~FSonyInputProcessor() override {}
-	virtual void Tick(const float DeltaTime, FSlateApplication& SlateApp, TSharedRef<ICursor> Cursor) override {};
+	virtual void Tick(const float DeltaTime, FSlateApplication& SlateApp, TSharedRef<ICursor> Cursor) override {}
 	virtual bool HandleMouseMoveEvent(FSlateApplication& SlateApp, const FPointerEvent& MouseEvent) override;
 	virtual bool HandleMouseButtonDownEvent(FSlateApplication& SlateApp, const FPointerEvent& MouseEvent) override;
 	virtual bool HandleMouseButtonUpEvent(FSlateApplication& SlateApp, const FPointerEvent& MouseEvent) override;
 	virtual bool HandleMouseButtonDoubleClickEvent(FSlateApplication& SlateApp, const FPointerEvent& MouseEvent) override;
 	virtual bool HandleMouseWheelOrGestureEvent(FSlateApplication& SlateApp, const FPointerEvent& InWheelEvent,
-		const FPointerEvent* InGestureEvent) override;
+	                                            const FPointerEvent* InGestureEvent) override;
 	virtual bool HandleMotionDetectedEvent(FSlateApplication& SlateApp, const FMotionEvent& MotionEvent) override;
 	virtual const TCHAR* GetDebugName() const override;
-
 
 	/**
 	 * Handles a key-down event and verifies if the input originates from a Sony controller.

--- a/Source/WindowsDualsense_ds5w/Public/WindowsDualsense_ds5w.h
+++ b/Source/WindowsDualsense_ds5w/Public/WindowsDualsense_ds5w.h
@@ -12,9 +12,6 @@
 #include "Framework/Application/SlateApplication.h"
 #endif
 
-
-
-
 /**
  * The FWindowsDualsense_ds5wModule class represents a module for handling DualSense input devices
  * on the Windows platform. It integrates with the Unreal Engine input device system, allowing
@@ -55,7 +52,7 @@ public:
 	 * @return A shared pointer to the created input device instance, or nullptr if initialization fails.
 	 */
 	virtual TSharedPtr<IInputDevice> CreateInputDevice(
-		const TSharedRef<FGenericApplicationMessageHandler>& InCustomMessageHandler) override;
+	    const TSharedRef<FGenericApplicationMessageHandler>& InCustomMessageHandler) override;
 
 	/**
 	 * A shared pointer that manages an instance of the DualSense input device.
@@ -84,14 +81,13 @@ private:
 
 #if PLATFORM_LINUX || PLATFORM_MAC
 	/**
-     * A shared pointer to an instance of an input processor for handling custom input logic.
-     *
-     * SonyInputProcessor is used to manage additional input processing, such as handling
-     * specific events or logic related to PlayStation controllers. It operates independently
-     * or in conjunction with the main input device to provide enhanced input functionality
-     * for the DualSense controller.
-     */
-    TSharedPtr<IInputProcessor> SonyInputProcessor;
+	 * A shared pointer to an instance of an input processor for handling custom input logic.
+	 *
+	 * SonyInputProcessor is used to manage additional input processing, such as handling
+	 * specific events or logic related to PlayStation controllers. It operates independently
+	 * or in conjunction with the main input device to provide enhanced input functionality
+	 * for the DualSense controller.
+	 */
+	TSharedPtr<IInputProcessor> SonyInputProcessor;
 #endif
-	
 };


### PR DESCRIPTION
This commit:
1. Adds clang-format config that matches UnrealEngine codestyle as close as posible
2. Adds `ClangFormat.sh` script that can be used on Linux, macOS and Windows (assuming Git Bash is installed) to reformat all code
3. Adds GitHub Actions job that checks codestyle conformance