### PR TITLE
Reorder include directives for consistency

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/API/SonyGamepadTriggerProxy.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/API/SonyGamepadTriggerProxy.cpp
@@ -3,8 +3,8 @@
 // Planned Release Year: 2025
 
 #include "API/SonyGamepadTriggerProxy.h"
-#include "Core/Types/Enums/EDeviceCommons.h"
 #include "API/SonyGamepadProxyHelpers.h"
+#include "Core/Types/Enums/EDeviceCommons.h"
 
 using namespace SonyGamepadProxyHelpers;
 

--- a/Source/WindowsDualsense_ds5w/Private/Core/Managers/DeviceRegistry.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/Managers/DeviceRegistry.cpp
@@ -5,14 +5,14 @@
 #include "Core/Managers/DeviceRegistry.h"
 #include "Async/Async.h"
 #include "Async/TaskGraphInterfaces.h"
-#include "Implementations/Libraries/DualSense/DualSenseLibrary.h"
-#include "Implementations/Libraries/DualShock/DualShockLibrary.h"
 #include "Core/Interfaces/IPlatformHardwareInfo.h"
 #include "Core/Interfaces/ISonyGamepad.h"
 #include "Core/Types/Structs/DeviceContext.h"
 #include "Core/Types/Structs/OutputContext.h"
 #include "GameFramework/InputSettings.h"
 #include "HAL/PlatformProcess.h"
+#include "Implementations/Libraries/DualSense/DualSenseLibrary.h"
+#include "Implementations/Libraries/DualShock/DualShockLibrary.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 TSharedPtr<FDeviceRegistry> FDeviceRegistry::Instance;
@@ -31,7 +31,7 @@ void FDeviceRegistry::DetectedChangeConnections(float DeltaTime)
 		{
 			return;
 		}
-		
+
 		if (AccumulatorDelta < 2.0f)
 		{
 			return;

--- a/Source/WindowsDualsense_ds5w/Private/Helpers/CommandHelpers.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Helpers/CommandHelpers.cpp
@@ -3,11 +3,11 @@
 // Planned Release Year: 2025
 
 #include "Helpers/CommandHelpers.h"
-#include "Core/Managers/DeviceRegistry.h"
 #include "Core/Interfaces/ISonyGamepad.h"
-#include "Implementations/Utils/PlayStationOutputComposer.h"
+#include "Core/Managers/DeviceRegistry.h"
 #include "Core/Types/Structs/DeviceContext.h"
 #include "HAL/IConsoleManager.h"
+#include "Implementations/Utils/PlayStationOutputComposer.h"
 
 static FAutoConsoleCommand GCmd_SetAudioByte(
     TEXT("ds.SetAudioByte"),

--- a/Source/WindowsDualsense_ds5w/Private/Implementations/Utils/PlayStationOutputComposer.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Implementations/Utils/PlayStationOutputComposer.cpp
@@ -4,8 +4,8 @@
 
 #include "Implementations/Utils/PlayStationOutputComposer.h"
 #include "Core/Interfaces/IPlatformHardwareInfo.h"
-#include "Core/Types/Structs/DeviceContext.h"
 #include "Core/Types/Enums/EDeviceConnection.h"
+#include "Core/Types/Structs/DeviceContext.h"
 
 const uint32 FPlayStationOutputComposer::CRCSeed = 0xeada2d49;
 

--- a/Source/WindowsDualsense_ds5w/Private/Subsystems/AudioHapticsListener.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Subsystems/AudioHapticsListener.cpp
@@ -3,9 +3,9 @@
 // Planned Release Year: 2025
 
 #include "Subsystems/AudioHapticsListener.h"
-#include "Core/Managers/DeviceRegistry.h"
-#include "Core/Interfaces/Segregations/IGamepadAudioHaptics.h"
 #include "API/SonyGamepadProxyHelpers.h"
+#include "Core/Interfaces/Segregations/IGamepadAudioHaptics.h"
+#include "Core/Managers/DeviceRegistry.h"
 
 FAudioHapticsListener::FAudioHapticsListener(FInputDeviceId InDeviceId, USoundSubmix* InSubmix)
     : Submix(InSubmix)

--- a/Source/WindowsDualsense_ds5w/Public/API/SonyGamepadBaseProxy.h
+++ b/Source/WindowsDualsense_ds5w/Public/API/SonyGamepadBaseProxy.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "Core/Interfaces/ISonyGamepad.h"
 #include "Core/Types/Enums/EDeviceCommons.h"
 #include "Core/Types/Enums/EDeviceConnection.h"
-#include "Core/Interfaces/ISonyGamepad.h"
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
 #if PLATFORM_WINDOWS

--- a/Source/WindowsDualsense_ds5w/Public/API/SonyGamepadProxyHelpers.h
+++ b/Source/WindowsDualsense_ds5w/Public/API/SonyGamepadProxyHelpers.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "Core/Managers/DeviceRegistry.h"
 #include "Core/Interfaces/ISonyGamepad.h"
+#include "Core/Managers/DeviceRegistry.h"
 #include "CoreMinimal.h"
 #include "GenericPlatform/GenericApplicationMessageHandler.h"
 

--- a/Source/WindowsDualsense_ds5w/Public/Implementations/Libraries/DualSense/DualSenseLibrary.h
+++ b/Source/WindowsDualsense_ds5w/Public/Implementations/Libraries/DualSense/DualSenseLibrary.h
@@ -6,10 +6,10 @@
 
 #include "Async/TaskGraphInterfaces.h"
 #include "Containers/Queue.h"
-#include "Core/Types/Enums/EDeviceCommons.h"
 #include "Core/Interfaces/ISonyGamepad.h"
 #include "Core/Interfaces/Segregations/IGamepadAudioHaptics.h"
 #include "Core/Interfaces/Segregations/IGamepadTrigger.h"
+#include "Core/Types/Enums/EDeviceCommons.h"
 #include "Core/Types/Structs/DeviceContext.h"
 #include "Core/Types/Structs/DualSenseFeatureReport.h"
 #include "CoreMinimal.h"


### PR DESCRIPTION
Adjusted the order of #include directives across multiple files to improve consistency and maintain coding standards. No functional changes were made.