### PR TITLE
Migrate to SDL3

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Commons/CommonsDeviceInfo.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Core/Platforms/Commons/CommonsDeviceInfo.cpp
@@ -6,7 +6,7 @@
 
 #if PLATFORM_WINDOWS
 #else
-#include "SDL_hidapi.h"
+#include "SDL3/SDL_hidapi.h"
 
 static const uint16 SONY_VENDOR_ID = 0x054C;
 static const uint16 DUALSHOCK4_PID_V1 = 0x05C4;
@@ -146,7 +146,7 @@ bool FCommonsDeviceInfo::CreateHandle(FDeviceContext* Context)
 	}
 
 	const FTCHARToUTF8 PathConverter(*Context->Path);
-	const FPlatformDeviceHandle Handle = SDL_hid_open_path(PathConverter.Get(), true);
+	const FPlatformDeviceHandle Handle = SDL_hid_open_path(PathConverter.Get());
 	if (Handle == INVALID_PLATFORM_HANDLE)
 	{
 		return false;

--- a/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
@@ -6,7 +6,7 @@
 
 #if PLATFORM_LINUX || PLATFORM_MAC
 #include "Framework/Application/SlateApplication.h"
-#include "SDL.h"
+#include "SDL3/SDL.h"
 #include "Subsystems/SonyInputProcessor.h"
 #endif
 #include "DeviceManager.h"
@@ -20,7 +20,7 @@ void FWindowsDualsense_ds5wModule::StartupModule()
 	IModularFeatures::Get().RegisterModularFeature(IInputDeviceModule::GetModularFeatureName(), this);
 	RegisterCustomKeys();
 #if PLATFORM_LINUX || PLATFORM_MAC
-	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) != 0)
+	if (!SDL_InitSubSystem(SDL_INIT_GAMEPAD))
 	{
 		UE_LOG(LogTemp, Error, TEXT("Failed to initialize subsystems of SDL: %s"), UTF8_TO_TCHAR(SDL_GetError()));
 	}

--- a/Source/WindowsDualsense_ds5w/Public/Core/Structs/DeviceContext.h
+++ b/Source/WindowsDualsense_ds5w/Public/Core/Structs/DeviceContext.h
@@ -13,7 +13,7 @@ using FPlatformDeviceHandle = HANDLE;
 #define INVALID_PLATFORM_HANDLE INVALID_HANDLE_VALUE
 
 #elif PLATFORM_MAC || PLATFORM_LINUX
-#include "SDL_hidapi.h"
+#include "SDL3/SDL_hidapi.h"
 using FPlatformDeviceHandle = SDL_hid_device*;
 #define INVALID_PLATFORM_HANDLE nullptr
 #else

--- a/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
+++ b/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
@@ -24,7 +24,7 @@ public class WindowsDualsense_ds5w : ModuleRules
 	    
 		if (Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.Mac)
 		{
-			PrivateDependencyModuleNames.AddRange(new string[] { "SDL2" });
+			PrivateDependencyModuleNames.AddRange(new string[] { "SDL3" });
 		}
 	}
 }


### PR DESCRIPTION
Unreal engine has migrated to SDL3 since version 5.7, this patch migrates to the new version (based on https://dev.epicgames.com/documentation/en-us/unreal-engine/updating-unreal-engine-on-linux-to-sdl3 and the SDL migration guide linked there).

This patched version has been tested on Linux with a Dualshock controller only.