### PR TITLE
Add support for SDL3 (needed for Unreal engine >= 5.7 on linux)

### DIFF
--- a/Source/WindowsDualsense_ds5w/Private/Implementations/Platforms/Commons/CommonsDeviceInfo.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/Implementations/Platforms/Commons/CommonsDeviceInfo.cpp
@@ -10,7 +10,13 @@
 #include "GCore/Types/Structs/Config/GamepadCalibration.h"
 #include "GCore/Types/Structs/Context/DeviceContext.h"
 #include "GImplementations/Utils/GamepadSensors.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+#include "SDL3/SDL_hidapi.h"
+#include "SDL3/SDL_version.h"
+#else
 #include "SDL_hidapi.h"
+#include "SDL_version.h"
+#endif
 #include <cstring>
 #include <string>
 #include <unordered_set>
@@ -209,7 +215,11 @@ bool FCommonsDeviceInfo::CreateHandle(FDeviceContext* Context)
 	}
 
 	const char* Path = Context->Path.data();
+#if SDL_MAJOR_VERSION >= 3
+	const FPlatformDeviceHandle Handle = SDL_hid_open_path(Path);
+#else
 	const FPlatformDeviceHandle Handle = SDL_hid_open_path(Path, true);
+#endif
 	if (Handle == INVALID_PLATFORM_HANDLE)
 	{
 		return false;

--- a/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
+++ b/Source/WindowsDualsense_ds5w/Private/WindowsDualsense_ds5w.cpp
@@ -12,7 +12,11 @@
 
 #if PLATFORM_LINUX || PLATFORM_MAC
 #include "Framework/Application/SlateApplication.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+#include "SDL3/SDL.h"
+#else
 #include "SDL.h"
+#endif
 #include "Subsystems/SonyInputProcessor.h"
 #endif
 #include "DeviceManager.h"
@@ -35,7 +39,11 @@ void FWindowsDualsense_ds5wModule::StartupModule()
 	FDeviceRegistry::Initialize();
 
 #elif PLATFORM_LINUX || PLATFORM_MAC
+#if SDL_MAJOR_VERSION >= 3
+	if (!SDL_InitSubSystem(SDL_INIT_GAMEPAD))
+#else
 	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) != 0)
+#endif
 	{
 		UE_LOG(LogDualSense, Error, TEXT("Failed to initialize subsystems of SDL: %s"), UTF8_TO_TCHAR(SDL_GetError()));
 	}

--- a/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
+++ b/Source/WindowsDualsense_ds5w/WindowsDualsense_ds5w.Build.cs
@@ -29,7 +29,14 @@ public class WindowsDualsense_ds5w : ModuleRules
 	    
 		if (Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.Mac)
 		{
-			PrivateDependencyModuleNames.AddRange(new string[] { "SDL2" });
+			if ( Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 7)
+			{
+				PrivateDependencyModuleNames.AddRange(new string[] { "SDL3" });
+			}
+			else
+			{
+				PrivateDependencyModuleNames.AddRange(new string[] { "SDL2" });
+			}
 		}
 	}
 }


### PR DESCRIPTION
This patch adds support for SDL3 and uses it on unreal >= 5.7 on linux/macos as Unreal Engine has migrated to that version starting with 5.7 (https://dev.epicgames.com/documentation/en-us/unreal-engine/updating-unreal-engine-on-linux-to-sdl3)

This has only been briefly tested with Unreal engine 5.7.1 on Linux with a DualShock4